### PR TITLE
nur/update: also include nix-prefetch-git in script closure

### DIFF
--- a/nur/update.py
+++ b/nur/update.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p python3 -p nix -i python3
+#!nix-shell -p python3 -p nix-prefetch-git -p nix -i python3
 
 import json
 import shutil


### PR DESCRIPTION
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.

Note: The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
