### PR TITLE
NixOS module support: Separate NUR nixpkgs from repos nixpkgs, avoid callPackages

### DIFF
--- a/lib/evalRepo.nix
+++ b/lib/evalRepo.nix
@@ -1,0 +1,34 @@
+{ name
+, url
+, src
+, pkgs # Do not use this for anything other than passing it along as an argument to the repository
+, lib
+}:
+let
+
+  prettyName = "[32;1m${name}[0m";
+
+  # Arguments passed to each repositories default.nix
+  passedArgs = {
+    pkgs = if pkgs != null then pkgs else throw ''
+      NUR import call didn't receive a pkgs argument, but the evaluation of NUR's ${prettyName} repository requires it.
+
+      This is either because
+        - You're trying to use a [1mpackage[0m from that repository, but didn't pass a `pkgs` argument to the NUR import.
+          In that case, refer to the installation instructions at https://github.com/nix-community/nur#installation on how to properly import NUR
+
+        - You're trying to use a [1mmodule[0m/[1moverlay[0m from that repository, but it didn't properly declare their module.
+          In that case, inform the maintainer of the repository: ${url}
+    '';
+  };
+
+  expr = import src;
+  args = builtins.functionArgs expr;
+  # True if not all arguments are either passed by default (e.g. pkgs) or defaulted (e.g. foo ? 10)
+  usesCallPackage = ! lib.all (arg: lib.elem arg (lib.attrNames passedArgs) || args.${arg}) (lib.attrNames args);
+
+in if usesCallPackage then lib.warn ''
+    NUR repository ${prettyName} is using the deprecated callPackage syntax which
+    might result in infinite recursion when used with NixOS modules.
+  '' (passedArgs.pkgs.callPackages src {})
+  else expr (builtins.intersectAttrs args passedArgs)


### PR DESCRIPTION
This is essential to get modules in NUR to work. By taking a separate
argument for NUR's nixpkgs (for fetchgit, fetchzip and lib), we don't
need to evaluate the nixpkgs used for repos.

This also implies that you won't be able to `callPackage` NUR anymore,
and instead you'll have to use `import (builtins.fetchGit ".../NUR") {
inherit pkgs; }` instead. Doing this also prevents the evaluation of
pkgs. In case of NixOS, this pkgs depends on your whole config, which is
the source of the recursion. Evaluating this at the last possible moment
is key.

This also means that you won't be able to take package arguments in a
repo definition, you instead get just `pkgs`, also to avoid evaluation
of it.

New install instructions would be
```nix
{
  packageOverrides = pkgs: {
    nur = import (builtins.fetchGit "https://github.com/nix-community/NUR") {
      inherit pkgs;
    };
  };
}
```

To get NixOS modules to work you'll have to use something like
```nix
{ pkgs, ... }:
let
  nur = import (builtins.fetchGit "https://github.com/nix-community/NUR") {
    inherit pkgs;
  };
in {
  imports = [
    nur.repos.infinisil.module
  ];
}
```

Preferably one would set `nur=https://github.com/nix-community/NUR` in their NIX_PATH, which allows one to do
```nix
{ pkgs, ... }: {
  imports = [
    (import <nur> { inherit pkgs; }).repos.infinisil.module
  ];
}
```

Also the pkgs argument should be made optional, so you don't even need to pass it when importing a module.

Docs and stuff would need to be updated, I might do this later.