### PR TITLE
Add kampka repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -9,6 +9,9 @@
         "fgaz": {
             "url": "https://github.com/fgaz/nur-packages"
         },
+        "kampka": {
+            "url": "https://github.com/kampka/nix-packages"
+        },
         "ma27": {
             "url": "https://gitlab.com/Ma27/nur-packages"
         },


### PR DESCRIPTION
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Note: The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
