### PR TITLE
Add submodule attribute to mpickering

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -29,6 +29,7 @@
             "url": "https://github.com/Mic92/nur-packages"
         },
         "mpickering": {
+            "submodules": true,
             "url": "https://github.com/mpickering/nur-packages"
         },
         "tilpner": {


### PR DESCRIPTION
This wasn't added in the origin PR.