### PR TITLE
Define modules as paths to functions, not functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,11 +295,12 @@ NixOS modules should be placed in the `modules` attribute:
 ```nix
 # modules/default.nix
 {
-  example-module = import ./example-module.nix;
+  example-module = ./example-module.nix;
 }
 ```
 
 An example can be found [here](https://github.com/Mic92/nur-packages/tree/master/modules).
+Modules should be defined as paths, not functions, to avoid conflicts if imported from multiple locations.
 
 #### Providing Overlays
 


### PR DESCRIPTION
This is to avoid conflicts when imported from multiple locations.

Example: Module nur.repos.foo.modules.bar defines an option.
If nur.repos.foo.modules.bar is a function, importing it from
multiple places will result in defining the option multiple times,
which the module system doesn't support.

If it instead is a path, there won't be a conflict, the option
will only be defined once.

cc @Infinisil @Mic92 