### PR TITLE
add johnazoidberg repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -19,6 +19,9 @@
         "izorkin": {
             "url": "https://github.com/Izorkin/nur-packages"
         },
+        "johnazoidberg": {
+            "url": "https://github.com/JohnAZoidberg/nur-packages"
+        },
         "kampka": {
             "url": "https://github.com/kampka/nix-packages"
         },


### PR DESCRIPTION
Everything builds when I run `nix-build` in my repository but `./bin/nur update` doesn't want to evaluate it because of restricted mode. I guess it's because the builtin fetchTarball isn't allowed but something that creates a derivation (i.e. fetchFromGitHub) is? Or how should I fetch my sources?
```
[...]
while evaluating the attribute 'src' of the derivation 'tpm-tss-2.0.1' at /nix/store/797yi4rh4mzs1vfx6im9yznc9l4sj7bb-source/pkgs/stdenv/generic/make-derivation.nix:175:11:
access to URI 'https://github.com/tpm2-software/tpm2-tss/releases/download/2.0.1/tpm2-tss-2.0.1.tar.gz' is forbidden in restricted mode
[...]
```

The following points apply when adding a new repository to repos.json

- [x] I ran nur/format-manifest.py after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarifiction where license should apply: 
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.