### PR TITLE
repos: add 'mozilla' repo

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -51,6 +51,10 @@
         "mic92": {
             "url": "https://github.com/Mic92/nur-packages"
         },
+        "mozilla": {
+            "file": "package-set.nix",
+            "url": "https://github.com/mozilla/nixpkgs-mozilla"
+        },
         "mpickering": {
             "submodules": true,
             "url": "https://github.com/mpickering/nur-packages"


### PR DESCRIPTION
Fixes #32

The following points apply when adding a new repository to repos.json

- [x] I ran nur/format-manifest.py after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.

I can't give the above permission, [but nixpkgs-mozilla is MIT-licensed](https://github.com/mozilla/nixpkgs-mozilla/blob/master/LICENSE).

Clarifiction where license should apply: 
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
