### PR TITLE
Minor doc proofreading

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ from source and **are not reviewed by any Nixpkgs member**.
 The NUR was created to share new packages from the community in a faster and
 more decentralized way.
 
-NUR automatically check its list of repositories and perform evaluation checks
-before it propagated the updates.
+NUR automatically checks its list of repositories and performs evaluation checks
+before it propagates the updates.
 
 ## Installation
 
@@ -85,8 +85,8 @@ environment.systemPackages = with pkgs; [
 Each contributor can register their repository under a name and is responsible
 for its content.
 
-***NUR does not check repository for malicious content on a regular base and it is
-recommend to check expression before installing them.***
+***NUR does not check the repository for malicious content on a regular basis
+and it is recommended to check the expressions before installing them.***
 
 ### Using modules overlays or library functions in NixOS
 


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [ ] I ran nur/format-manifest.py after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarifiction where license should apply: 
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
