### PR TITLE
Add bhipple to NUR

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1,5 +1,8 @@
 {
     "repos": {
+        "bhipple": {
+            "url": "https://github.com/bhipple/nur-packages"
+        },
         "crazedprogrammer": {
             "file": "pkgs/nur-packages.nix",
             "url": "https://github.com/CrazedProgrammer/nix"

--- a/repos.json.lock
+++ b/repos.json.lock
@@ -1,5 +1,10 @@
 {
     "repos": {
+        "bhipple": {
+            "rev": "2e5e5e92a0d282484483401ee2ab83af8c36d829",
+            "sha256": "1avrj74dkarz3lavn7yvz7jdis7fhamkpds7wabd9x3s79bnmdzc",
+            "url": "https://github.com/bhipple/nur-packages"
+        },
         "crazedprogrammer": {
             "rev": "426548a87bda27b38e006e9f0e31da2a14a3a070",
             "sha256": "1dg8bzk00lss5akk5h64z3vvkc7k7kszm5ri2lf4vwv16zagma63",


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran nur/format-manifest.py after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarifiction where license should apply: 
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
