### PR TITLE
add kalbasit repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -29,6 +29,9 @@
         "johnazoidberg": {
             "url": "https://github.com/JohnAZoidberg/nur-packages"
         },
+        "kalbasit": {
+            "url": "https://github.com/kalbasit/nur-packages"
+        },
         "kampka": {
             "url": "https://github.com/kampka/nix-packages"
         },

--- a/repos.json.lock
+++ b/repos.json.lock
@@ -45,6 +45,11 @@
             "sha256": "045zhnjxvff16hnbhkvhqa1j48cz8rbmsnxa6jwihfmai4caa872",
             "url": "https://github.com/JohnAZoidberg/nur-packages"
         },
+        "kalbasit": {
+            "rev": "726801774ab5780b43e3713833005e12778e748a",
+            "sha256": "04xjx7al9adv82c1jg5d6g3wfaaln7si4w72id76m63xl6di8446",
+            "url": "https://github.com/kalbasit/nur-packages"
+        },
         "kampka": {
             "rev": "92c2a48b1ab91ed94af7683a22b4206de69e3b51",
             "sha256": "0isa0vvzfv963hdd4z84dc9s0wh4lwcacqgl6529vp8f9x6qpzdm",


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` and `./bin/nur update` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarifiction where license should apply: 
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
