### PR TITLE
remove restricted-eval

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -26,7 +26,7 @@ fi
 
 export encrypted_080f214a372c_key= encrypted_080f214a372c_iv=
 
-nix-build release.nix
+nix-build --quiet release.nix
 
 if ! is-automatic-update; then
   bash $DIR/lint.sh

--- a/nur/update.py
+++ b/nur/update.py
@@ -36,6 +36,7 @@ import {EVALREPO_PATH} {{
             "-qa", "*",
             "--meta",
             "--xml",
+            "--allowed-uris", "https://static.rust-lang.org",
             "--option", "restrict-eval", "true",
             "--option", "allow-import-from-derivation", "true",
             "--drv-path",


### PR DESCRIPTION
It seems that many tooling like yarn2nix, stack2nix as well
as the builtins fetchgit and fetchurl need this.
Sadly we also give up reproducible evaluation here
and also untrusted evaluation becomes an issue (can this be used
to export travis ci secrets?)