### PR TITLE
repos.manveru: remove

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -55,9 +55,6 @@
             "file": "nur.nix",
             "url": "https://github.com/makefu/nur-packages"
         },
-        "manveru": {
-            "url": "https://github.com/manveru/nur-packages"
-        },
         "matthewbauer": {
             "url": "https://github.com/matthewbauer/nur-packages"
         },

--- a/repos.json.lock
+++ b/repos.json.lock
@@ -86,11 +86,6 @@
             "sha256": "0vm4cj7jjhkn25vh1mrw4zvy1a5l5h031fba3lpchkbc9v0pplcb",
             "url": "https://github.com/makefu/nur-packages"
         },
-        "manveru": {
-            "rev": "fecba576d85e9a0aa44c18bb7b69b05299060deb",
-            "sha256": "16gvpvf12crlkzzl1y9ysnbnh3ai03dpfali20zwpailar9xz53k",
-            "url": "https://github.com/manveru/nur-packages"
-        },
         "matthewbauer": {
             "rev": "21b678d31d567730921dd932fef6682694715b65",
             "sha256": "0h5al1rd3pklk5m76g47l5c34l272grappbaracxi9ryzmsxckc4",


### PR DESCRIPTION
This repository does not evaluate for ages.
I don't know how to these yarn2nix packages evaluate.
