### PR TITLE
repos.ma27: nur-packages -> nixexprs

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -49,7 +49,7 @@
             "url": "https://github.com/lschuermann/nur-packages"
         },
         "ma27": {
-            "url": "https://gitlab.com/Ma27/nur-packages"
+            "url": "https://gitlab.com/Ma27/nixexprs"
         },
         "makefu": {
             "file": "nur.nix",


### PR DESCRIPTION
As I renamed the repository in GitLab it's still possible to clone
`nur-packages`, however it's IMHO better to stay in sync with the
upstream settings.

The rename happened as `-packages` is an unsuitable suffix as I use the
repo for modules and library functions as well.
