### PR TITLE
Add vdemeester repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -81,6 +81,9 @@
         "tilpner": {
             "url": "https://github.com/tilpner/nur-packages"
         },
+        "vdemeester": {
+            "url": "https://github.com/vdemeester/nur-packages"
+        },
         "yurrriq": {
             "url": "https://github.com/yurrriq/nur-packages"
         }

--- a/repos.json.lock
+++ b/repos.json.lock
@@ -127,6 +127,11 @@
             "sha256": "03nb18djcvyq1xmf4z3msrv4pv1rqqs9nx0kc1bi9vv38n1hr3zl",
             "url": "https://github.com/tilpner/nur-packages"
         },
+        "vdemeester": {
+            "rev": "34e2bac0b72b2de27600af810385f8f783bb7668",
+            "sha256": "14mvigib7kx774rg28q8pkgbf4myh0wnz9hq205kdn7s4iac7jw0",
+            "url": "https://github.com/vdemeester/nur-packages"
+        },
         "yurrriq": {
             "rev": "8e5b634818de538664d3ef080bb90e3b56e7da01",
             "sha256": "1lkqnmbg2a6a2psf16p61cvkwy0bfy2a75ca11kiik0p0y4lybqy",


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

The following points apply when adding a new repository to repos.json

- [x] I ran nur/format-manifest.py after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarifiction where license should apply: 
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
