### PR TITLE
Add documentation on home-manager Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ in {
 
 ### Integrating with Home Manager
 
-Integrating with the home-manager can be done by adding your modules to the `imports` attribute.
+Integrating with [Home Manager](https://github.com/rycee/home-manager) can be done by adding your modules to the `imports` attribute.
 You can then configure your services like usual.
 
 ```nix

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ let
   nur-no-pkgs = import (builtins.fetchTarball "https://github.com/nix-community/NUR/archive/master.tar.gz") {};
 in
 {
-  imports = lib.attrValues nur-no-pkgs.repos.moredhel.home-manager.modules;
+  imports = lib.attrValues nur-no-pkgs.repos.moredhel.hmModules.modules;
 
   services.unison = {
     enable = true;

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ in {
 }
 ```
 
-### Integrating with HomeManager
+### Integrating with Home Manager
 
 Integrating with the home-manager can be done by adding your modules to the `imports` attribute.
 You can then configure your services like usual.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,28 @@ in {
 }
 ```
 
+### Integrating with HomeManager
+
+Integrating with the home-manager can be done by adding your modules to the `extraModules` attribute.
+You can then configure your services like usual.
+
+```nix
+{
+  extraModules = nur.repos.moredhel.home-manager.modules;
+
+  services.unison = {
+    enable = true;
+    profiles = {
+      org = {
+        src = "/home/user/org";"
+        dest = "/home/user/org.backup";
+        extraArgs = "-batch -watch -ui text -repeat 60 -fat";
+      };
+    };
+  };
+}
+```
+
 ## Finding packages
 
 At the moment we do not have a dedicated package search available. However our

--- a/README.md
+++ b/README.md
@@ -111,19 +111,22 @@ in {
 
 ### Integrating with HomeManager
 
-Integrating with the home-manager can be done by adding your modules to the `extraModules` attribute.
+Integrating with the home-manager can be done by adding your modules to the `imports` attribute.
 You can then configure your services like usual.
 
 ```nix
+let
+  nur-no-pkgs = import (builtins.fetchTarball "https://github.com/nix-community/NUR/archive/master.tar.gz") {};
+in
 {
-  extraModules = nur.repos.moredhel.home-manager.modules;
+  imports = lib.attrValues nur-no-pkgs.repos.moredhel.home-manager.modules;
 
   services.unison = {
     enable = true;
     profiles = {
       org = {
-        src = "/home/user/org";"
-        dest = "/home/user/org.backup";
+        src = "/home/moredhel/org";"
+        dest = "/home/moredhel/org.backup";
         extraArgs = "-batch -watch -ui text -repeat 60 -fat";
       };
     };


### PR DESCRIPTION
This PR is waiting on a PR on home-manager.
A patch was needed so user-defined modules can be defined.

https://github.com/rycee/home-manager/pull/470

- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarifiction where license should apply: 
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.