### PR TITLE
Add repoOverrides

### DIFF
--- a/lib/repoSource.nix
+++ b/lib/repoSource.nix
@@ -22,6 +22,8 @@ let
 in
   if lib.pathExists localPath then
     "${localPath}"
+  else if type == "path" then
+    builtins.toPath attr.url
   else if lib.hasPrefix "https://github.com" attr.url && !submodules then
     fetchzip {
       url = "${attr.url}/archive/${revision.rev}.zip";


### PR DESCRIPTION
Includes [my](https://github.com/bb010g/nur-packages) NUR repo, the [neXromancers](https://github.com/neXromancers/nixromancers) NUR repo, and an argument to allow for overrides of repos on invocation. Pretty straightforward, and here's how I used it to work on packaging these smoothly:

```nix
repoOverrides = {
  bb010g = { type = "path"; url = ~/nix/nur-bb010g; };
  nexromancers = { type = "path"; url = ~/nix/nur-nexromancers; };
}
```

Yes, you could do this by symlinking in directories to the proper places in `<NUR/repos>`, but this feels a lot more idiomatic to me, also supports testing non-local repositories, and does not require a local NUR clone.

- [X] I ran nur/format-manifest.py after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [X] By including this repository in NUR I give permission to license the
content under the MIT license.