### PR TITLE
Allow for longer CI by wrapping in travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: nix
 script:
-  - bash ci/deploy.sh
+  - travis_wait 30 bash ci/deploy.sh


### PR DESCRIPTION
This might fix builds like this:
https://travis-ci.com/nix-community/NUR/builds/96090296