### PR TITLE
nur/update: drop eval output instead of filling pipe

### DIFF
--- a/nur/update.py
+++ b/nur/update.py
@@ -50,7 +50,7 @@ import {EVALREPO_PATH} {{
 
         logger.info(f"Evaluate repository {repo.name}")
         proc = subprocess.Popen(
-            cmd, env=dict(PATH=os.environ["PATH"]), stdout=subprocess.PIPE
+            cmd, env=dict(PATH=os.environ["PATH"]), stdout=subprocess.DEVNULL
         )
         try:
             res = proc.wait(5)


### PR DESCRIPTION
Since nothing reads the pipe, writes block indefinitely
once the pipe's buffer is full.

------

Apparently my repo now produces enough output
(at least as meta xml?) that the pipe buffer filled
causing indefinite eval hang.