### PR TITLE
Added piensa geospatial nur-packages

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -88,6 +88,9 @@
         "peel": {
             "url": "https://github.com/peel/nur-packages"
         },
+        "piensa": {
+            "url": "https://github.com/piensa/nur-packages"
+        },
         "pschuprikov": {
             "url": "https://github.com/pschuprikov/nur-packages"
         },

--- a/repos.json
+++ b/repos.json
@@ -89,7 +89,7 @@
             "url": "https://github.com/peel/nur-packages"
         },
         "piensa": {
-            "url": "https://github.com/piensa/nur-packages"
+            "url": "https://github.com/piensa/nur-packages" 
         },
         "pschuprikov": {
             "url": "https://github.com/pschuprikov/nur-packages"

--- a/repos.json
+++ b/repos.json
@@ -89,7 +89,7 @@
             "url": "https://github.com/peel/nur-packages"
         },
         "piensa": {
-            "url": "https://github.com/piensa/nur-packages" 
+            "url": "https://github.com/piensa/nur-packages"
         },
         "pschuprikov": {
             "url": "https://github.com/pschuprikov/nur-packages"


### PR DESCRIPTION
Because spatial is special

The following points apply when adding a new repository to repos.json

- [x] I ran nur/format-manifest.py after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
