### PR TITLE
add INFO4-19 repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -3,6 +3,10 @@
         "0x4a6f": {
             "url": "https://github.com/0x4A6F/nur-packages"
         },
+        "INFO4-19": {
+            "type": "gitlab",
+            "url": "https://gricad-gitlab.univ-grenoble-alpes.fr/Projets-INFO4/18-19/19/code/tree/daniel/nur-packages"
+        },
         "bb010g": {
             "url": "https://github.com/bb010g/nur-packages"
         },

--- a/repos.json
+++ b/repos.json
@@ -5,7 +5,7 @@
         },
         "INFO4-19": {
             "type": "gitlab",
-            "url": "https://gricad-gitlab.univ-grenoble-alpes.fr/Projets-INFO4/18-19/19/code/tree/daniel/nur-packages"
+            "url": "https://gricad-gitlab.univ-grenoble-alpes.fr/Projets-INFO4/18-19/19/code/nur-packages"
         },
         "bb010g": {
             "url": "https://github.com/bb010g/nur-packages"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran nur/format-manifest.py after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
