### PR TITLE
Add tox repo

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -122,6 +122,9 @@
         "tilpner": {
             "url": "https://github.com/tilpner/nur-packages"
         },
+        "tox": {
+            "url": "https://github.com/tox-rs/nur-tox"
+        },
         "vdemeester": {
             "url": "https://github.com/vdemeester/nur-packages"
         },


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran nur/format-manifest.py after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Unfortunately, `bin/nur` is broken:

```
=================================== FAILURES ===================================
_________________________________ FLAKE8-check _________________________________
/build/jaraco.logging-2.0/jaraco/logging.py:15:2: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:24:3: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:29:2: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:43:2: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:54:2: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:67:2: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:78:3: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:84:3: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:90:4: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:94:4: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:98:3: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:102:3: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:106:3: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:108:4: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:111:3: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:118:4: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:128:4: E117 over-indented (comment)
/build/jaraco.logging-2.0/jaraco/logging.py:129:4: E117 over-indented (comment)
/build/jaraco.logging-2.0/jaraco/logging.py:130:4: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:132:4: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:136:3: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:145:4: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:146:5: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:148:4: E117 over-indented (comment)
/build/jaraco.logging-2.0/jaraco/logging.py:149:4: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:153:3: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:157:4: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:159:4: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:163:2: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:174:3: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:179:3: E117 over-indented
/build/jaraco.logging-2.0/jaraco/logging.py:182:4: E117 over-indented

====================== 1 failed, 4 passed in 0.56 seconds ======================
builder for '/nix/store/9b1hycrlgcbg9y9yp90labp409ysii8w-python3.7-jaraco.logging-2.0.drv' failed with exit code 1
cannot build derivation '/nix/store/dbn4r5g1msnqinmnzvv1x95sync5h3xx-python3.7-irc-17.0.drv': 1 dependencies couldn't be built
error: build of '/nix/store/dbn4r5g1msnqinmnzvv1x95sync5h3xx-python3.7-irc-17.0.drv' failed
```
