### PR TITLE
add babariviere repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -14,6 +14,9 @@
         "awl-fcarza": {
             "url": "https://github.com/francescocarzaniga/awl-fcarza"
         },
+        "babariviere": {
+            "url": "https://github.com/babariviere/nur-packages"
+        },
         "balsoft": {
             "url": "https://github.com/balsoft/nur-packages"
         },


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [X] I ran nur/format-manifest.py after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [X] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
