### PR TITLE
Add my nur-repo to the NUR :D

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -42,6 +42,9 @@
             "file": "pkgs/nur-packages.nix",
             "url": "https://github.com/CrazedProgrammer/nix"
         },
+        "dandellion": {
+            "url": "https://git.dodsorf.as/Dandellion/NUR"
+        },
         "dezgeg": {
             "url": "https://github.com/dezgeg/nur-packages"
         },


### PR DESCRIPTION
Really cool project this here

The following points apply when adding a new repository to repos.json

- [ ] I ran nur/format-manifest.py after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [X] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
