### PR TITLE
Add me :D

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -86,6 +86,9 @@
         "izorkin": {
             "url": "https://github.com/Izorkin/nur-packages"
         },
+        "jd91mzm2": {
+            "url": "https://gitlab.com/jD91mZM2/nur-packages"
+        },
         "johnazoidberg": {
             "url": "https://github.com/JohnAZoidberg/nur-packages"
         },

--- a/repos.json.lock
+++ b/repos.json.lock
@@ -96,8 +96,8 @@
             "url": "https://github.com/dtn7/nur-packages"
         },
         "dtz": {
-            "rev": "df26b4fbb96157df1e146c24779c8640d2382575",
-            "sha256": "0js8c7nq86p50bfxappvnr5p90kkihv4fqmj7ng8v23dv8xz5hw9",
+            "rev": "70ee742a20f75a56ceb26c09da5b627454d62eec",
+            "sha256": "0l4pd63ibdw3xzlia370qbykkwfg3n4c03d0jacnm0445j6iq2lm",
             "url": "https://github.com/dtzWill/nur-packages"
         },
         "dywedir": {
@@ -136,8 +136,8 @@
             "url": "https://github.com/Izorkin/nur-packages"
         },
         "jd91mzm2": {
-            "rev": "b9f77eb8f9fdc8a71b943a02ce4a5b9eb911862d",
-            "sha256": "04zisdmia28xnqrgwyqbx6qdab7sk4vhly7l4pyfgcp3pvr0j3sy",
+            "rev": "dafda79b2205ee834596b44ad1cfc396f72e5107",
+            "sha256": "1nvd9di8hhki07qrdzw0szxa99aajd87bh6gldg1730r787fxppz",
             "url": "https://gitlab.com/jD91mZM2/nur-packages"
         },
         "johnazoidberg": {

--- a/repos.json.lock
+++ b/repos.json.lock
@@ -135,6 +135,11 @@
             "sha256": "0cn2sh54l41kr1i8qxsg3n0z7x1imgbng33957nvjsan9np3vm9f",
             "url": "https://github.com/Izorkin/nur-packages"
         },
+        "jd91mzm2": {
+            "rev": "b9f77eb8f9fdc8a71b943a02ce4a5b9eb911862d",
+            "sha256": "04zisdmia28xnqrgwyqbx6qdab7sk4vhly7l4pyfgcp3pvr0j3sy",
+            "url": "https://gitlab.com/jD91mZM2/nur-packages"
+        },
         "johnazoidberg": {
             "rev": "48769217a4f800d83bd33006cabf4eebb8739951",
             "sha256": "0f2v9iq21ipsx9kiwssgqwwisdsy2wx9zfasy9qvvx5y17r4sqpz",


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
