### PR TITLE
Inital working flake implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,30 @@ in
 }
 ```
 
+### Flake Support
+
+Using overlays and modules from NUR in your configuration is fairly straight
+forward.
+
+In your flake.nix:
+```nix
+inputs.nur.url = github:nix-community/NUR;
+
+outputs = {self, nixpkgs, nur }:
+{
+  nixosConfigurations.myConfig = nixpkgs.lib.nixosSystem {
+    # ...
+    modules = [
+      ({
+        nixpkgs.overlays = [ nur."${nur-username}".overlays."${anOverlay}" ]
+      })
+      nur."${nur-username}".modules.${aModule}
+    ];
+  };
+}
+
+```
+
 ## Finding packages
 
 At the moment we do not have a dedicated package search available. However our

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,11 @@
+{
+    "inputs": {
+        "nixpkgs": {
+            "inputs": {},
+            "narHash": "sha256-NB+H7zK3BB//zM127FqgbG4iAfY+nS/IOyO+uGWA5Ho=",
+            "originalUrl": "nixpkgs",
+            "url": "github:edolstra/nixpkgs/7845bf5f4b3013df1cf036e9c9c3a55a30331db9"
+        }
+    },
+    "version": 3
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,9 +2,9 @@
     "inputs": {
         "nixpkgs": {
             "inputs": {},
-            "narHash": "sha256-NB+H7zK3BB//zM127FqgbG4iAfY+nS/IOyO+uGWA5Ho=",
+            "narHash": "sha256-OnpEWzNxF/AU4KlqBXM2s5PWvfI5/BS6xQrPvkF5tO8=",
             "originalUrl": "nixpkgs",
-            "url": "github:edolstra/nixpkgs/7845bf5f4b3013df1cf036e9c9c3a55a30331db9"
+            "url": "github:edolstra/nixpkgs/7f8d4b088e2df7fdb6b513bc2d6941f1d422a013"
         }
     },
     "version": 3

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,15 @@
+{
+  description = "Nix User Repository";
+
+  epoch = 201909;
+
+  outputs = { self, nixpkgs }:
+    {
+      overlay = final: prev: {
+        nur = import ./default.nix {
+          nurpkgs = nixpkgs;
+          pkgs = nixpkgs.pkgs;
+        };
+      };
+    };
+}


### PR DESCRIPTION
Resolves #174 by allowing those migrating to flakes to continue using NUR without breaking backwards compatibility for those that aren't.

Some packages or modules may be broken if they try to import anything from the
`NIX_PATH`. Many packages, overlays and modules work just fine without modification so this should still be quite useful.