### PR TITLE
add ptival repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -179,6 +179,9 @@
         "pschuprikov": {
             "url": "https://github.com/pschuprikov/nur-packages"
         },
+        "ptival": {
+            "url": "https://github.com/Ptival/nur-packages"
+        },
         "rummik": {
             "url": "https://gitlab.com/rummik/nixos/nur-packages"
         },


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [X] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [X] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
