### PR TITLE
add mrVanDalo/nur-packages

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -164,6 +164,9 @@
             "submodules": true,
             "url": "https://github.com/mpickering/nur-packages"
         },
+        "mrVanDalo": {
+            "url": "https://github.com/mrVanDalo/nur-packages"
+        },
         "n1kolasM": {
             "url": "https://github.com/n1kolasM/nur-packages"
         },


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
