### PR TITLE
Add my nixpkgs repo to NUR

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -233,6 +233,9 @@
         "vdemeester": {
             "url": "https://github.com/vdemeester/nur-packages"
         },
+        "xe": {
+            "url": "https://tulpa.dev/Xe/nixpkgs"
+        },
         "ysndr": {
             "url": "https://github.com/ysndr/nur-packages"
         },

--- a/repos.json
+++ b/repos.json
@@ -234,7 +234,6 @@
             "url": "https://github.com/vdemeester/nur-packages"
         },
         "xe": {
-            "type": "gitea",
             "url": "https://tulpa.dev/Xe/nixpkgs"
         },
         "ysndr": {

--- a/repos.json
+++ b/repos.json
@@ -234,6 +234,7 @@
             "url": "https://github.com/vdemeester/nur-packages"
         },
         "xe": {
+            "type": "gitea",
             "url": "https://tulpa.dev/Xe/nixpkgs"
         },
         "ysndr": {


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.