### PR TITLE
add "Why are my NUR packages not updating?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,11 @@ override existing packages.
 Also without coordination multiple overlays could easily introduce dependency
 cycles.
 
+## Why are my NUR packages not updating?
+With every build triggered via the URL hook all repositories will be evaluated.Only if the evaluation does not contain errors the repository revision for the user is updated. Typical evaluation errors are in the meta data of a derivation like a wrong license attribute.
+
+You can find out if your evaluation succeeded by checking the [latest travis build job]( https://travis-ci.com/github/nix-community/NUR/ ).
+
 ## Contact
 
 You can chat with us on IRC in channel [#nixos-nur](https://webchat.freenode.net/?url=irc%3A%2F%2Firc.freenode.net%2Fnixos-nur).


### PR DESCRIPTION
Add some troubleshooting information to find out why the nur repos do not get updated.

The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
