### PR TITLE
add pwnytail's nur-packages repo

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -216,6 +216,9 @@
         "ptival": {
             "url": "https://github.com/Ptival/nur-packages"
         },
+        "pwnytail": {
+            "url": "https://gitlab01.bsd.services/pwnytail/nur-packages"
+        }
         "rencire": {
             "submodules": true,
             "url": "https://github.com/rencire/nur-packages"

--- a/repos.json
+++ b/repos.json
@@ -218,7 +218,7 @@
         },
         "pwnytail": {
             "url": "https://gitlab01.bsd.services/pwnytail/nur-packages"
-        }
+        },
         "rencire": {
             "submodules": true,
             "url": "https://github.com/rencire/nur-packages"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
  - run not successfully: 
> build input /nix/store/lqb5bai8a28mg4p8l98a4l0zm8sr6msd-python3.7-irc-17.0 does not exist

- [X] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
