### PR TITLE
Update vdemeester NUR repository (and file)

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -273,7 +273,8 @@
             "url": "https://github.com/trevorriles/nur-packages"
         },
         "vdemeester": {
-            "url": "https://github.com/vdemeester/nur-packages"
+            "file": "pkgs/default.nix",
+            "url": "https://gitlab.com/vdemeester/home"
         },
         "wamserma": {
             "url": "https://github.com/wamserma/nur-packages"


### PR DESCRIPTION
Updating the repository to get NUR packages.

---

The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
