### PR TITLE
add jjjollyjim repositry

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -113,6 +113,9 @@
         "jd91mzm2": {
             "url": "https://gitlab.com/jD91mZM2/nur-packages"
         },
+        "jjjollyjim": {
+            "url": "https://github.com/jjjollyjim/nur-repo"
+        },
         "johnazoidberg": {
             "url": "https://github.com/JohnAZoidberg/nur-packages"
         },


### PR DESCRIPTION
Planning to add a bunch of tools to attempt to bring the nix ecosystem closer to Kali Linux or BlackArch, not all of which will belong in nixpkgs.

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
