### PR TITLE
combine.py: handle symlinks when copying tree

### DIFF
--- a/nur/combine.py
+++ b/nur/combine.py
@@ -51,7 +51,7 @@ def commit_repo(repo: Repo, message: str, path: Path) -> Repo:
     assert tmp is not None
 
     try:
-        copy_tree(repo_source(repo.name), tmp.name)
+        copy_tree(repo_source(repo.name), tmp.name, preserve_symlinks=1)
         shutil.rmtree(repo_path, ignore_errors=True)
         os.rename(tmp.name, repo_path)
         tmp = None
@@ -169,7 +169,7 @@ def setup_combined() -> None:
         write_json_file(dict(repos={}), manifest_path)
 
     manifest_lib = "lib"
-    copy_tree(str(ROOT.joinpath("lib")), manifest_lib)
+    copy_tree(str(ROOT.joinpath("lib")), manifest_lib, preserve_symlinks=1)
     default_nix = "default.nix"
     shutil.copy(ROOT.joinpath("default.nix"), default_nix)
 


### PR DESCRIPTION
By default `copy_tree` do not preserve symlinks and tries to resolve
them. If the symlinks is pointing to a non-existent target it will
fail.

This fixes that by copying symlinks as such, aka preserve_symlinks.

Closes #229

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

cc @Mic92 