### PR TITLE
add ivar repo

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -101,6 +101,9 @@
         "immae": {
             "url": "https://git.immae.eu/perso/Immae/Config/Nix/NUR.git"
         },
+        "ivar": {
+            "url": "https://github.com/IvarWithoutBones/NUR"
+        },
         "izorkin": {
             "url": "https://github.com/Izorkin/nur-packages"
         },


### PR DESCRIPTION
- [X] I ran `./bin/nur format-manifest` after updating `repos.json`
- [X] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
