### PR TITLE
Fix flake for new nixFlakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,11 +1,27 @@
 {
-    "inputs": {
-        "nixpkgs": {
-            "inputs": {},
-            "narHash": "sha256-OnpEWzNxF/AU4KlqBXM2s5PWvfI5/BS6xQrPvkF5tO8=",
-            "originalUrl": "nixpkgs",
-            "url": "github:edolstra/nixpkgs/7f8d4b088e2df7fdb6b513bc2d6941f1d422a013"
-        }
+  "nodes": {
+    "nixpkgs": {
+      "info": {
+        "lastModified": 1590824667,
+        "narHash": "sha256-ut9bcUiG3LKIQtvLrhivTGqvjSP87fLlPssepQy7Ikg="
+      },
+      "locked": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "89e60f61ab6f09362433fd23370c590cd47e9c72",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
     },
-    "version": 3
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 5
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,6 @@
 {
   description = "Nix User Repository";
 
-  epoch = 201909;
-
   outputs = { self, nixpkgs }:
     {
       overlay = final: prev: {


### PR DESCRIPTION
Current version of nixFlakes from nixpkgs-unstable does not support 'epoch' attribute and flake.lock format for version 3. This PR removes obsolete attribute and updates flake.lock version

The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
