### PR TITLE
add piegames repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ notifications:
     template:
       - "%{result} - %{branch} \"%{commit_subject}\" %{build_url}"
 
+before_script:
+  - echo "trusted-users = $USER" | sudo tee -a /etc/nix/nix.conf
+  - sudo systemctl restart nix-daemon
 jobs:
   include:
     - name: test pull request

--- a/repos.json
+++ b/repos.json
@@ -239,6 +239,9 @@
         "peel": {
             "url": "https://github.com/peel/nur-packages"
         },
+        "piegames": {
+            "url": "https://github.com/piegamesde/nur-packages"
+        },
         "piensa": {
             "url": "https://github.com/piensa/nur-packages"
         },


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
