### PR TITLE
Add user agent header for fetch latest commit

### DIFF
--- a/nur/prefetch.py
+++ b/nur/prefetch.py
@@ -13,9 +13,10 @@ from .manifest import LockedVersion, Repo, RepoType
 
 
 def fetch_commit_from_feed(url: str) -> str:
-    req = urllib.request.urlopen(url)
+    req = urllib.request.Request(url, headers={"User-Agent": "nur-updater"})
+    res = urllib.request.urlopen(req)
     try:
-        xml = req.read()
+        xml = res.read()
         root = ET.fromstring(xml)
         ns = "{http://www.w3.org/2005/Atom}"
         xpath = f"./{ns}entry/{ns}link"


### PR DESCRIPTION
For some reason GitLab (or CloudFlare) respond with 403 Forbidden for requests made using urllib. By setting the user agent we can complete the requests successfully.

See https://gitlab.com/gitlab-org/gitlab/-/issues/219669 for the corresponding issue in the GitLab issue tracker.