### PR TITLE
add instantos repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -108,6 +108,9 @@
         "immae": {
             "url": "https://git.immae.eu/perso/Immae/Config/Nix/NUR.git"
         },
+        "instantos": {
+            "url": "https://github.com/instantOS/nix"
+        },
         "ivar": {
             "url": "https://github.com/IvarWithoutBones/NUR"
         },


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Added instantos repository.