### PR TITLE
Revert shamilton block

### DIFF
--- a/nur/combine.py
+++ b/nur/combine.py
@@ -130,10 +130,6 @@ def update_combined(path: Path) -> List[str]:
 
     for repo in manifest.repos:
         combined_repo = None
-        if repo.name == "shamilton":
-            logger.info("Skip shamilton due to https://github.com/nix-community/nur-combined/commit/00b4f9809c#r41441760")
-            continue
-
         if repo.name in combined_repos:
             combined_repo = combined_repos[repo.name]
             del combined_repos[repo.name]

--- a/nur/update.py
+++ b/nur/update.py
@@ -76,9 +76,6 @@ def update_command(args: Namespace) -> None:
     manifest = load_manifest(MANIFEST_PATH, LOCK_PATH)
 
     for repo in manifest.repos:
-        if repo.name == "shamilton":
-            print("Skip shamilton due to https://github.com/nix-community/nur-combined/commit/00b4f9809c#r41441760")
-
         try:
             update(repo)
         except EvalError as err:


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
