### PR TITLE
add nerdypepper/npkgs

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -236,6 +236,9 @@
         "nexromancers": {
             "url": "https://github.com/neXromancers/nixromancers"
         },
+        "npkgs": {
+            "url": "https://github.com/nerdypepper/npkgs"
+        },
         "nprindle": {
             "url": "https://github.com/nprindle/nur-packages"
         },


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.

---

### `./bin/nur update` fails

This step was listed in the readme, but not in the PR template, so I am not sure if I should be running this, but running `./bin/nur update` fails for various repositories, (almost always) erroring out with:

```
access to URI [...] is forbidden in restricted mode
```
and the script exits before evaluating `nerdypepper/npkgs`, is there anything I can do about this (perhaps I should open a new issue)? I am running NixOS 20.03.
