### PR TITLE
add jechol repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -132,6 +132,9 @@
         "jd91mzm2": {
             "url": "https://gitlab.com/jD91mZM2/nur-packages"
         },
+        "jechol": {
+            "url": "https://github.com/jechol/nur-packages"
+        },
         "jjjollyjim": {
             "url": "https://github.com/jjjollyjim/nur-repo"
         },


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [ O ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [ O ] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
