### PR TITLE
add htr repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -108,6 +108,9 @@
         "gricad": {
             "url": "https://github.com/Gricad/nur-packages"
         },
+        "htr": {
+            "url": "https://github.com/htr/nur-packages"
+        },
         "ilya-fedin": {
             "url": "https://github.com/ilya-fedin/nur-repository"
         },


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
