### PR TITLE
Patch 1

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -142,8 +142,8 @@
         "jd91mzm2": {
             "url": "https://gitlab.com/jD91mZM2/nur-packages"
         },
-        "jechol": {
-            "url": "https://github.com/jechol/nur-packages"
+        "beam": {
+            "url": "https://github.com/jechol/nix-beam"
         },
         "jjjollyjim": {
             "url": "https://github.com/jjjollyjim/nur-repo"

--- a/repos.json
+++ b/repos.json
@@ -33,6 +33,9 @@
         "bb010g": {
             "url": "https://github.com/bb010g/nur-packages"
         },
+        "beam": {
+            "url": "https://github.com/jechol/nix-beam"
+        },
         "bendlas": {
             "url": "https://github.com/bendlas/nur-packages"
         },
@@ -141,9 +144,6 @@
         },
         "jd91mzm2": {
             "url": "https://gitlab.com/jD91mZM2/nur-packages"
-        },
-        "beam": {
-            "url": "https://github.com/jechol/nix-beam"
         },
         "jjjollyjim": {
             "url": "https://github.com/jjjollyjim/nur-repo"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
