### PR TITLE
rename 0x4a6f repo to _0x4A6F

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1,11 +1,12 @@
 {
     "repos": {
-        "0x4a6f": {
-            "url": "https://github.com/0x4A6F/nur-packages"
-        },
         "INFO4-19": {
             "type": "gitlab",
             "url": "https://gricad-gitlab.univ-grenoble-alpes.fr/Projets-INFO4/18-19/19/code"
+        },
+        "_0x4A6F": {
+            "github-contact": "0x4A6F",
+            "url": "https://github.com/0x4A6F/nur-packages"
         },
         "aasg": {
             "github-contact": "AluisioASG",


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
