### PR TITLE
Add qchem repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -299,6 +299,10 @@
         "pwnytail": {
             "url": "https://gitlab01.bsd.services/pwnytail/nur-packages"
         },
+        "qchem": {
+            "file": "nur.nix",
+            "url": "https://github.com/markuskowa/NixOS-QChem"
+        },
         "reedrw": {
             "url": "https://github.com/reedrw/nur-packages"
         },


### PR DESCRIPTION
Closes https://github.com/markuskowa/NixOS-QChem/issues/5

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.


