### PR TITLE
add lucasew repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -202,6 +202,10 @@
         "lschuermann": {
             "url": "https://github.com/lschuermann/nur-packages"
         },
+        "lucasew": {
+            "file": "nur.nix",
+            "url": "https://github.com/lucasew/nixcfg"
+        },
         "makefu": {
             "file": "nur.nix",
             "url": "https://github.com/makefu/nur-packages"


### PR DESCRIPTION
Signed-off-by: lucasew <lucas59356@gmail.com>

The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.

 Note: the checks have failed because of a typo, it happens :shrug: and its already fixed
