### PR TITLE
add j-k repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -190,6 +190,10 @@
             "github-contact": "Izorkin",
             "url": "https://github.com/Izorkin/nur-packages"
         },
+        "j-k": {
+            "github-contact": "06kellyjac",
+            "url": "https://github.com/06kellyjac/nur-packages"
+        },
         "jakobrs": {
             "github-contact": "jakobrs",
             "url": "https://github.com/jakobrs/nur-packages"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [X] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [X] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.

---

As a note I had to remove the following from `repos.json` as https://github.com/yoctocell/nur-packages doesn't exist anymore:

```json
"yoctocell": {
  "github-contact": "yoctocell",
  "url": "https://github.com/yoctocell/nur-packages"
},
```