### PR TITLE
Improved the "Attribute" column on nur-search

### DIFF
--- a/nur/index.py
+++ b/nur/index.py
@@ -54,7 +54,6 @@ callPackage (nur.repo-sources."%s" + "/%s") {}
                 stripped = path.parts[4:]
                 attrPath = "/".join(stripped[1:])
                 location = f"{prefixes[stripped[0]]}{attrPath}"
-                print(stripped, file=sys.stderr)
                 pkg["meta"]["position"] = f"{location}#L{line}"
             elif position is not None and position.find("nur-combined") > -1:
                 path_str, line = position.rsplit(":", 1)

--- a/nur/index.py
+++ b/nur/index.py
@@ -39,13 +39,12 @@ callPackage (nur.repo-sources."%s" + "/%s") {}
             position = pkg["meta"].get("position", None)
             # TODO commit hash
             prefix = f"https://github.com/nix-community/nur-combined/tree/master/repos/{repo}"
-            # usually when the path comes from the nix store
             if position is not None and position.startswith("/nix/store"):
                 path_str, line = position.rsplit(":", 1)
                 path = Path(path_str)
                 # I've decided to just take these 2 repositories,
                 # update this whenever someone decided to use a recipe source other than
-                # NUR on nixpkgs to override packages on. right now this is about as accurate as
+                # NUR or nixpkgs to override packages on. right now this is about as accurate as
                 # `nix edit` is
                 # TODO find commit hash
                 prefixes = {

--- a/nur/index.py
+++ b/nur/index.py
@@ -49,7 +49,7 @@ callPackage (nur.repo-sources."%s" + "/%s") {}
                 # TODO find commit hash
                 prefixes = {
                     "nixpkgs": "https://github.com/nixos/nixpkgs/tree/master/",
-                    "nur": "https://github.com/nix-community/nur-combined/tree/master/"
+                    "nur": "https://github.com/nix-community/nur-combined/tree/master/",
                 }
                 stripped = path.parts[4:]
                 attrPath = "/".join(stripped[1:])

--- a/repos.json.lock
+++ b/repos.json.lock
@@ -152,8 +152,8 @@
             "url": "https://github.com/dtzWill/nur-packages"
         },
         "dukzcry": {
-            "rev": "cefb081491a247c98ea8c03397472f071f66acc8",
-            "sha256": "0zd2ndsr3jhb3kh132cd0dh3277br0g2c1h8rxp5jgj02bplp1s6",
+            "rev": "5ca7027bd717ff2b684d60517959b62e33dd05ed",
+            "sha256": "18m4sxh9cjfwnjbszz2520dhbly38p3qd8s330cvp1dqzkh5ijb9",
             "url": "https://github.com/repos-holder/nur-packages"
         },
         "dywedir": {
@@ -375,8 +375,8 @@
             "url": "https://github.com/mhuesch/nur-packages"
         },
         "mic92": {
-            "rev": "663b8ca827960eddd55742113735905cc0198198",
-            "sha256": "1f4pg37z3ipzmns3vgxvhbr6b2s7gmba8mdqkmyzr9ikbbbi1cdw",
+            "rev": "5566f36aba616a9c91049c180f4f81536eef98e4",
+            "sha256": "1i453nk8qwxl81pi0afq33ljn2pf5366b090d9xiwa0smi4vb26j",
             "url": "https://github.com/Mic92/nur-packages"
         },
         "mmilata": {

--- a/repos.json.lock
+++ b/repos.json.lock
@@ -96,8 +96,8 @@
             "url": "https://github.com/cransom/nur-packages"
         },
         "crazazy": {
-            "rev": "59b518edc5932fe35dc18f0d352b11ffc70ea43c",
-            "sha256": "0m83qfm6l3mfbyn0mddyg85w9lqk78a7c6rllcc5vmjplxmydayn",
+            "rev": "c83dc0a8c9ace1ac01ef354d6d550cd8d414c56b",
+            "sha256": "0id2j8khv7n1vxjwfddn0k7a7l2rzzilyivvw4spvma2amhlirfp",
             "url": "https://github.com/crazazy/nixos-config"
         },
         "crazedprogrammer": {
@@ -172,8 +172,8 @@
             "url": "https://github.com/emiller88/nur-packages"
         },
         "emmanuelrosa": {
-            "rev": "8bf610d7b1b078a9d7f30982fbfe29410c6090b7",
-            "sha256": "006ydz1y17x8bgad6rppi0pnn0pjm4vagnh56w34y8145lxikxbk",
+            "rev": "f738663fed99f2ca66fcca7765e1d461c1ce5f43",
+            "sha256": "07f6pszcphg0vn76ss732pg9j6g9xysz7103zal7gagajhdk1dr2",
             "url": "https://github.com/emmanuelrosa/nur-packages"
         },
         "extends": {
@@ -375,8 +375,8 @@
             "url": "https://github.com/mhuesch/nur-packages"
         },
         "mic92": {
-            "rev": "5566f36aba616a9c91049c180f4f81536eef98e4",
-            "sha256": "1i453nk8qwxl81pi0afq33ljn2pf5366b090d9xiwa0smi4vb26j",
+            "rev": "98e37dc3785f222a40a6f6305ae5bc46fb3105fb",
+            "sha256": "0fvgmxj49qf5icv7hjc1dv486mcgjz07s44f205wk5p7ssl6mwz0",
             "url": "https://github.com/Mic92/nur-packages"
         },
         "mmilata": {
@@ -567,8 +567,8 @@
             "url": "https://github.com/SCOTT-HAMILTON/nur-packages-template"
         },
         "sikmir": {
-            "rev": "6573f6882743d8db0ea0df642a16846ed2064d73",
-            "sha256": "06j5iyb7kcr6128f9bcrgxi3fhgvwshfj5ybsrsg144zrgv2s3sn",
+            "rev": "e456da8fbb0c82f7b18e45a0d9e49b07082aea97",
+            "sha256": "08h6jhavp1m1wzn69rynzri1giz2llbk5dkzb8cqrl0bb9rv2mir",
             "url": "https://github.com/sikmir/nur-packages"
         },
         "smaret": {


### PR DESCRIPTION
Fixes #308 

This makes the link that the attribute goes to a bit more precise. It redirects you to the same source page that `nix edit` would. That is not to say that the link is always accurate (not that `nix edit` *is*) but it should send you to the exact line that a derivation is declared