### PR TITLE
ci/nur-search: run make clean

### DIFF
--- a/ci/update-nur-search.sh
+++ b/ci/update-nur-search.sh
@@ -29,7 +29,7 @@ if [[ ! -z "$(git diff --exit-code)" ]]; then
     git commit -m "automatic update package.json"
     git pull --rebase origin master
     git push origin master
-    nix-shell --run "make && make publish"
+    nix-shell --run "make clean && make && make publish"
 else
     echo "nothings changed will not commit anything"
 fi


### PR DESCRIPTION
public should be rebuild from a clean state when packages.json are
changed, thus removing obsolete repos.