### PR TITLE
Improving the attributes section of nur-search: part 2

### DIFF
--- a/nur/index.py
+++ b/nur/index.py
@@ -29,9 +29,9 @@ def resolve_source(pkg: Dict, repo: str, url: str) -> str:
             canonical_url = url
             # if we want to add the option of specifying branches, we have to update this
             if "github" in url:
-                canonical_url += "/blob/master/"
+                canonical_url += "/blob/HEAD/"
             elif "gitlab" in url:
-                canonical_url += "/-/blob/master/"
+                canonical_url += "/-/blob/HEAD/"
             attr_path = "/".join(stripped)
             location = f"{canonical_url}{attr_path}"
             return f"{location}#L{line}"

--- a/nur/index.py
+++ b/nur/index.py
@@ -50,11 +50,21 @@ callPackage (nur.repo-sources."%s" + "/%s") {}
                 prefixes = {
                     "nixpkgs": "https://github.com/nixos/nixpkgs/tree/master/",
                     "nur": "https://github.com/nix-community/nur-combined/tree/master/",
-                    # this tends to come up when nur-combined isn't indexed yet
-                    "pkgs": url + "/",
                 }
                 stripped = path.parts[4:]
-                if stripped[0] not in prefixes:
+                if path.parts[3].endswith("source"):
+                    def url_contains(host: str) -> bool:
+                        return url.find(host) != -1
+                    canonical_url = url
+                    if url_contains("github"):
+                        canonical_url += "/blob"
+                    elif url_contains("gitlab"):
+                        canonical_url += "/-/blob"
+                    attrPath = "/".join(stripped)
+                    location = f"{canonical_url}{attrPath}"
+                    pkg["meta"]["position"] = f"{location}#L{line}"
+                elif stripped[0] not in prefixes:
+                    print(path, file=sys.stderr)
                     print(
                         f"we could not find {stripped} , you can file an issue at https://github.com/nix-community/NUR/issues to the indexing file if you think this is a mistake",
                         file=sys.stderr,

--- a/nur/index.py
+++ b/nur/index.py
@@ -7,7 +7,9 @@ from tempfile import NamedTemporaryFile
 from typing import Any, Dict
 
 
-def index_repo(directory: Path, repo: str, expression_file: str, url: str) -> Dict[str, Any]:
+def index_repo(
+    directory: Path, repo: str, expression_file: str, url: str
+) -> Dict[str, Any]:
     default_nix = directory.joinpath("default.nix").resolve()
     expr = """
 with import <nixpkgs> {};
@@ -53,8 +55,10 @@ callPackage (nur.repo-sources."%s" + "/%s") {}
                 }
                 stripped = path.parts[4:]
                 if path.parts[3].endswith("source"):
+
                     def url_contains(host: str) -> bool:
                         return url.find(host) != -1
+
                     canonical_url = url
                     if url_contains("github"):
                         canonical_url += "/blob"
@@ -93,7 +97,12 @@ def index_command(args: Namespace) -> None:
     pkgs: Dict[str, Any] = {}
 
     for (repo, data) in repos.items():
-        repo_pkgs = index_repo(directory, repo, data.get("file", "default.nix"), data.get("url", "https://github.com/nixos/nixpkgs"))
+        repo_pkgs = index_repo(
+            directory,
+            repo,
+            data.get("file", "default.nix"),
+            data.get("url", "https://github.com/nixos/nixpkgs"),
+        )
         pkgs.update(repo_pkgs)
 
     json.dump(pkgs, sys.stdout, indent=4)

--- a/nur/index.py
+++ b/nur/index.py
@@ -30,10 +30,11 @@ def resolve_source(pkg: Dict, repo: str, url: str) -> str:
                 return url.find(host) != -1
 
             canonical_url = url
+            # if we want to add the option of specifying branches, we have to update this
             if url_contains("github"):
-                canonical_url += "/blob/"
+                canonical_url += "/blob/master/"
             elif url_contains("gitlab"):
-                canonical_url += "/-/blob/"
+                canonical_url += "/-/blob/master/"
             attrPath = "/".join(stripped)
             location = f"{canonical_url}{attrPath}"
             return f"{location}#L{line}"

--- a/nur/index.py
+++ b/nur/index.py
@@ -7,7 +7,7 @@ from tempfile import NamedTemporaryFile
 from typing import Any, Dict
 
 
-def index_repo(directory: Path, repo: str, expression_file: str) -> Dict[str, Any]:
+def index_repo(directory: Path, repo: str, expression_file: str, url: str) -> Dict[str, Any]:
     default_nix = directory.joinpath("default.nix").resolve()
     expr = """
 with import <nixpkgs> {};
@@ -50,6 +50,8 @@ callPackage (nur.repo-sources."%s" + "/%s") {}
                 prefixes = {
                     "nixpkgs": "https://github.com/nixos/nixpkgs/tree/master/",
                     "nur": "https://github.com/nix-community/nur-combined/tree/master/",
+                    # this tends to come up when nur-combined isn't indexed yet
+                    "pkgs": url + "/",
                 }
                 stripped = path.parts[4:]
                 if stripped[0] not in prefixes:
@@ -81,7 +83,7 @@ def index_command(args: Namespace) -> None:
     pkgs: Dict[str, Any] = {}
 
     for (repo, data) in repos.items():
-        repo_pkgs = index_repo(directory, repo, data.get("file", "default.nix"))
+        repo_pkgs = index_repo(directory, repo, data.get("file", "default.nix"), data.get("url", "https://github.com/nixos/nixpkgs"))
         pkgs.update(repo_pkgs)
 
     json.dump(pkgs, sys.stdout, indent=4)

--- a/nur/index.py
+++ b/nur/index.py
@@ -26,14 +26,11 @@ def resolve_source(pkg: Dict, repo: str, url: str) -> str:
         stripped = path.parts[4:]
         if path.parts[3].endswith("source"):
 
-            def url_contains(host: str) -> bool:
-                return url.find(host) != -1
-
             canonical_url = url
             # if we want to add the option of specifying branches, we have to update this
-            if url_contains("github"):
+            if "github" in url:
                 canonical_url += "/blob/master/"
-            elif url_contains("gitlab"):
+            elif "gitlab" in url:
                 canonical_url += "/-/blob/master/"
             attrPath = "/".join(stripped)
             location = f"{canonical_url}{attrPath}"
@@ -49,7 +46,7 @@ def resolve_source(pkg: Dict, repo: str, url: str) -> str:
             attrPath = "/".join(stripped[1:])
             location = f"{prefixes[stripped[0]]}{attrPath}"
             return f"{location}#L{line}"
-    elif position is not None and position.find("nur-combined") > -1:
+    elif position is not None and "nur-combined" in position:
         path_str, line = position.rsplit(":", 1)
         stripped = path_str.partition(f"nur-combined/repos/{repo}")[2]
         return f"{prefix}{stripped}#L{line}"

--- a/nur/index.py
+++ b/nur/index.py
@@ -42,7 +42,22 @@ callPackage (nur.repo-sources."%s" + "/%s") {}
             if position is not None and position.startswith("/nix/store"):
                 path_str, line = position.rsplit(":", 1)
                 path = Path(path_str)
+                # I've decided to just take these 2 repositories,
+                # update this whenever someone decided to use a recipe source other than
+                # NUR or nixpkgs to override packages on. right now this is about as accurate as
+                # `nix edit` is
+                # TODO find commit hash
+                prefixes = {
+                    "nixpkgs": "https://github.com/nixos/nixpkgs/tree/master/",
+                    "nur": "https://github.com/nix-community/nur-combined/tree/master/",
+                }
                 stripped = path.parts[4:]
+                attrPath = "/".join(stripped[1:])
+                location = f"{prefixes[stripped[0]]}{attrPath}"
+                pkg["meta"]["position"] = f"{location}#L{line}"
+            elif position is not None and position.find("nur-combined") > -1:
+                path_str, line = position.rsplit(":", 1)
+                stripped = path_str.partition(f"nur-combined/repos/{repo}")[2]
                 pkg["meta"]["position"] = f"{prefix}{stripped}#L{line}"
             else:
                 pkg["meta"]["position"] = prefix

--- a/nur/index.py
+++ b/nur/index.py
@@ -32,8 +32,8 @@ def resolve_source(pkg: Dict, repo: str, url: str) -> str:
                 canonical_url += "/blob/master/"
             elif "gitlab" in url:
                 canonical_url += "/-/blob/master/"
-            attrPath = "/".join(stripped)
-            location = f"{canonical_url}{attrPath}"
+            attr_path = "/".join(stripped)
+            location = f"{canonical_url}{attr_path}"
             return f"{location}#L{line}"
         elif stripped[0] not in prefixes:
             print(path, file=sys.stderr)
@@ -43,8 +43,8 @@ def resolve_source(pkg: Dict, repo: str, url: str) -> str:
             )
             return prefix
         else:
-            attrPath = "/".join(stripped[1:])
-            location = f"{prefixes[stripped[0]]}{attrPath}"
+            attr_path = "/".join(stripped[1:])
+            location = f"{prefixes[stripped[0]]}{attr_path}"
             return f"{location}#L{line}"
     elif position is not None and "nur-combined" in position:
         path_str, line = position.rsplit(":", 1)

--- a/nur/index.py
+++ b/nur/index.py
@@ -53,7 +53,10 @@ callPackage (nur.repo-sources."%s" + "/%s") {}
                 }
                 stripped = path.parts[4:]
                 if stripped[0] not in prefixes:
-                    print(f"we could not find {stripped} , you can file an issue at https://github.com/nix-community/NUR/issues to the indexing file if you think this is a mistake", file=sys.stderr)
+                    print(
+                        f"we could not find {stripped} , you can file an issue at https://github.com/nix-community/NUR/issues to the indexing file if you think this is a mistake",
+                        file=sys.stderr,
+                    )
                     pkg["meta"]["position"] = prefix
                 else:
                     attrPath = "/".join(stripped[1:])

--- a/nur/index.py
+++ b/nur/index.py
@@ -61,9 +61,9 @@ callPackage (nur.repo-sources."%s" + "/%s") {}
 
                     canonical_url = url
                     if url_contains("github"):
-                        canonical_url += "/blob"
+                        canonical_url += "/blob/"
                     elif url_contains("gitlab"):
-                        canonical_url += "/-/blob"
+                        canonical_url += "/-/blob/"
                     attrPath = "/".join(stripped)
                     location = f"{canonical_url}{attrPath}"
                     pkg["meta"]["position"] = f"{location}#L{line}"

--- a/nur/index.py
+++ b/nur/index.py
@@ -52,9 +52,13 @@ callPackage (nur.repo-sources."%s" + "/%s") {}
                     "nur": "https://github.com/nix-community/nur-combined/tree/master/",
                 }
                 stripped = path.parts[4:]
-                attrPath = "/".join(stripped[1:])
-                location = f"{prefixes[stripped[0]]}{attrPath}"
-                pkg["meta"]["position"] = f"{location}#L{line}"
+                if stripped[0] not in prefixes:
+                    print(f"we could not find {stripped} , you can file an issue at https://github.com/nix-community/NUR/issues to the indexing file if you think this is a mistake", file=sys.stderr)
+                    pkg["meta"]["position"] = prefix
+                else:
+                    attrPath = "/".join(stripped[1:])
+                    location = f"{prefixes[stripped[0]]}{attrPath}"
+                    pkg["meta"]["position"] = f"{location}#L{line}"
             elif position is not None and position.find("nur-combined") > -1:
                 path_str, line = position.rsplit(":", 1)
                 stripped = path_str.partition(f"nur-combined/repos/{repo}")[2]

--- a/temp.nix
+++ b/temp.nix
@@ -1,5 +1,0 @@
-with import <nixpkgs> {};
-let
-  nur = import ./. { inherit pkgs;};
-in
-  callPackage (nur.repo-sources.crazazy + "/pkgs/default.nix")

--- a/temp.nix
+++ b/temp.nix
@@ -1,0 +1,5 @@
+with import <nixpkgs> {};
+let
+  nur = import ./. { inherit pkgs;};
+in
+  callPackage (nur.repo-sources.crazazy + "/pkgs/default.nix")


### PR DESCRIPTION
Fixes an issue with #309  This should now not error out when a custom path is encountered on the nix store

An improvement here would be if we could find out how the nix recipes got into the nix store in the first place, but I don't think that is possible
