### PR TITLE
Add repo "fendse"

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -158,6 +158,10 @@
             "github-contact": "ImExtends",
             "url": "https://github.com/ImExtends/nur-packages-template"
         },
+        "fendse": {
+            "github-contact": "fendse",
+            "url": "https://github.com/fendse/nur"
+        },
         "fgaz": {
             "github-contact": "fgaz",
             "url": "https://github.com/fgaz/nur-packages"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
