### PR TITLE
add afreak repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -13,6 +13,10 @@
             "github-contact": "AluisioASG",
             "url": "https://git.sr.ht/~aasg/nixexprs"
         },
+        "afreakk": {
+            "github-contact": "afreakk",
+            "url": "https://github.com/afreakk/mynixrepo"
+        },
         "andersontorres": {
             "github-contact": "andersontorres",
             "url": "https://github.com/AndersonTorres/nur-packages"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.

I get tons of errors when running `bin/nur update`, but not on my repo. so not sure, want to see if your CI gets errors :)

It did, not quite sure what its pointing to though