### PR TITLE
harcode git author in all commands

### DIFF
--- a/ci/lib/setup-git.sh
+++ b/ci/lib/setup-git.sh
@@ -1,5 +1,0 @@
-# only source this file
-# ==================================================
-
-git config --global user.name "Nur a bot"
-git config --global user.email "joerg.nur-bot@thalheim.io"

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p bash -i bash -p python3Packages.mypy -p python3Packages.black -p python3Packages.flake8
+#!nix-shell -p bash -i bash -p python3Packages.mypy -p python3Packages.black -p python3Packages.flake8 -p nix
 
 set -eux -o pipefail # Exit with nonzero exit code if anything fails
 

--- a/ci/update-nur-search.sh
+++ b/ci/update-nur-search.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p git -p bash -i bash
+#!nix-shell -p git -p nix -p bash -i bash
 
 set -eu -o pipefail # Exit with nonzero exit code if anything fails
 

--- a/ci/update-nur-search.sh
+++ b/ci/update-nur-search.sh
@@ -5,7 +5,6 @@ set -eu -o pipefail # Exit with nonzero exit code if anything fails
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-source ${DIR}/lib/setup-git.sh
 set -x
 
 
@@ -26,7 +25,7 @@ nix run '(import ./release.nix {})' -c nur index nur-combined > nur-search/data/
 cd nur-search
 if [[ ! -z "$(git diff --exit-code)" ]]; then
     git add ./data/packages.json
-    git commit -m "automatic update package.json"
+    git commit --author "Nur a bot <joerg.nur-bot@thalheim.io>" -m "automatic update package.json"
     git pull --rebase origin master
     git push origin master
     nix-shell --run "make clean && make && make publish"

--- a/ci/update-nur.sh
+++ b/ci/update-nur.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p git -p bash -i bash
+#!nix-shell -p git -p nix -p bash -i bash
 
 set -eu -o pipefail # Exit with nonzero exit code if anything fails
 

--- a/ci/update-nur.sh
+++ b/ci/update-nur.sh
@@ -23,7 +23,7 @@ if [[ -z "$(git diff --exit-code)" ]]; then
   echo "No changes to the output on this push; exiting."
 else
   git add --all repos.json*
-  git commit -m "automatic update"
+  git commit --author "Nur a bot <joerg.nur-bot@thalheim.io>" -m "automatic update"
   # in case we are getting overtaken by a different job
   git pull --rebase origin master
   git push "https://$API_TOKEN_GITHUB@github.com/nix-community/NUR" HEAD:master

--- a/nur/combine.py
+++ b/nur/combine.py
@@ -42,7 +42,16 @@ def commit_files(files: List[str], message: str) -> None:
     cmd.extend(files)
     subprocess.check_call(cmd)
     if repo_changed():
-        subprocess.check_call(["git", "commit", "-m", message])
+        subprocess.check_call(
+            [
+                "git",
+                "commit",
+                "--author",
+                "Nur a bot <joerg.nur-bot@thalheim.io>",
+                "-m",
+                message,
+            ]
+        )
 
 
 def commit_repo(repo: Repo, message: str, path: Path) -> Repo:


### PR DESCRIPTION
This makes it easier to locally test the commands without affecting ~/.gitconfigThe following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
