### PR TITLE
fix update-nur

### DIFF
--- a/ci/update-nur.sh
+++ b/ci/update-nur.sh
@@ -5,7 +5,6 @@ set -eu -o pipefail # Exit with nonzero exit code if anything fails
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-source ${DIR}/lib/setup-git.sh
 set -x
 
 nix run '(import ./release.nix {})' -c nur update


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
