### PR TITLE
use environment variables to set git identity

### DIFF
--- a/ci/lib/setup-git.sh
+++ b/ci/lib/setup-git.sh
@@ -1,0 +1,7 @@
+# only source this file
+# ==================================================
+
+export GIT_AUTHOR_NAME="Nur a bot"
+export GIT_AUTHOR_EMAIL="nixpkgs-review@example.com"
+export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
+export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL

--- a/ci/update-nur-search.sh
+++ b/ci/update-nur-search.sh
@@ -5,6 +5,7 @@ set -eu -o pipefail # Exit with nonzero exit code if anything fails
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
+source ${DIR}/lib/setup-git.sh
 set -x
 
 
@@ -25,7 +26,7 @@ nix run '(import ./release.nix {})' -c nur index nur-combined > nur-search/data/
 cd nur-search
 if [[ ! -z "$(git diff --exit-code)" ]]; then
     git add ./data/packages.json
-    git commit --author "Nur a bot <joerg.nur-bot@thalheim.io>" -m "automatic update package.json"
+    git commit "Nur a bot <joerg.nur-bot@thalheim.io>" -m "automatic update package.json"
     git pull --rebase origin master
     git push origin master
     nix-shell --run "make clean && make && make publish"

--- a/ci/update-nur.sh
+++ b/ci/update-nur.sh
@@ -3,8 +3,10 @@
 
 set -eu -o pipefail # Exit with nonzero exit code if anything fails
 
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
+source ${DIR}/lib/setup-git.sh
 set -x
 
 nix run '(import ./release.nix {})' -c nur update
@@ -22,7 +24,7 @@ if [[ -z "$(git diff --exit-code)" ]]; then
   echo "No changes to the output on this push; exiting."
 else
   git add --all repos.json*
-  git commit --author "Nur a bot <joerg.nur-bot@thalheim.io>" -m "automatic update"
+  git commit "Nur a bot <joerg.nur-bot@thalheim.io>" -m "automatic update"
   # in case we are getting overtaken by a different job
   git pull --rebase origin master
   git push "https://$API_TOKEN_GITHUB@github.com/nix-community/NUR" HEAD:master

--- a/nur/combine.py
+++ b/nur/combine.py
@@ -46,7 +46,6 @@ def commit_files(files: List[str], message: str) -> None:
             [
                 "git",
                 "commit",
-                "--author",
                 "Nur a bot <joerg.nur-bot@thalheim.io>",
                 "-m",
                 message,


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
