### PR TITLE
delete travis or change to github actions in docs and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,6 @@
 
 # CI
 /ci @Mic92 @zimbatm
-/.travis.yml @Mic92 @zimbatm
 
 # nix
 /lib @Infinisil

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 The following points apply when adding a new repository to repos.json
 
-- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in travis ci to make sure we keep the format consistent)
+- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
 - [ ] By including this repository in NUR I give permission to license the
 content under the MIT license.
 

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ option to a path relative to the repository root:
 ### Update NUR's lock file after updating your repository
 
 By default we only check for repository updates once a day with an automatic
-cron job in travis ci to update our lock file `repos.json.lock`.
+github action to update our lock file `repos.json.lock`.
 To update NUR faster, you can use our service at https://nur-update.herokuapp.com/
 after you have pushed an update to your repository, e.g.:
 
@@ -317,7 +317,7 @@ With every build triggered via the URL hook all repositories will be evaluated.O
 * Using a wrong license attribute in the metadata.
 * Using a builtin fetcher because it will cause access to external URLs during evaluation. Use pkgs.fetch* instead (i.e. instead of `builtins.fetchGit` use `pkgs.fetchgit`)
 
-You can find out if your evaluation succeeded by checking the [latest travis build job]( https://travis-ci.com/github/nix-community/NUR/ ).
+You can find out if your evaluation succeeded by checking the [latest build job](https://github.com/nix-community/NUR/actions).
 
 
 ### Git submodules


### PR DESCRIPTION
I think this is self-explaining. However, I'm not sure whether the note in the PR template still applies.