### PR TITLE
Allow changing branch name in repo manifest

### DIFF
--- a/nur/manifest.py
+++ b/nur/manifest.py
@@ -57,6 +57,7 @@ class Repo:
         submodules: bool,
         supplied_type: Optional[str],
         file_: Optional[str],
+        branch: Optional[str],
         locked_version: Optional[LockedVersion],
     ) -> None:
         self.name = name
@@ -66,6 +67,10 @@ class Repo:
             self.file = "default.nix"
         else:
             self.file = file_
+        if branch is None:
+            self.branch = "master"
+        else:
+            self.branch = branch
         self.locked_version = None
 
         if (
@@ -150,9 +155,10 @@ def load_manifest(manifest_path: PathType, lock_path: PathType) -> Manifest:
     for name, repo in data["repos"].items():
         url = urlparse(repo["url"])
         submodules = repo.get("submodules", False)
+        branch_ = repo.get("branch", "master")
         file_ = repo.get("file", "default.nix")
         type_ = repo.get("type", None)
         locked_version = locked_versions.get(name)
-        repos.append(Repo(name, url, submodules, type_, file_, locked_version))
+        repos.append(Repo(name, url, submodules, type_, file_, branch_, locked_version))
 
     return Manifest(repos)

--- a/repos.json
+++ b/repos.json
@@ -22,6 +22,7 @@
             "url": "https://gitlab.com/AlwinB/nur-packages"
         },
         "ambroisie": {
+            "branch": "main",
             "file": "pkgs/default.nix",
             "github-contact": "ambroisie",
             "url": "https://github.com/ambroisie/nix-config"

--- a/repos.json.lock
+++ b/repos.json.lock
@@ -25,6 +25,11 @@
             "sha256": "1s9ghnsj3rc6sdnpsy3g0wby76mxdvzaihsqw9981gcbl9dm32i6",
             "url": "https://gitlab.com/AlwinB/nur-packages"
         },
+        "ambroisie": {
+            "rev": "f4fe70bafe44d547945517460b66900a80d078d5",
+            "sha256": "0250xkimnwibr46zn04ksfqjr05fazd4a7mcwbm75lw0k13n2sfa",
+            "url": "https://github.com/ambroisie/nix-config"
+        },
         "andersontorres": {
             "rev": "d07f5349010ab2902787e27ce2c3a9e909838758",
             "sha256": "0vac1n3gkgqw2vjw8ka5g3fivrly44kjbl6gqvnf8p8vagbvrac3",


### PR DESCRIPTION
This should close #78.

When adding my repository, I did not notice that the update script would error out on my repository, because I use `main` instead of `master` (I had not seen that I was supposed to run `./bin/nur update` :upside_down_face:). In compensation for a broken first addition, allow me to add this feature purely for my own convenience :slightly_smiling_face:.

I took the liberty to add a commit with the option being used on my faulty repo, and the resulting lock file to show that it worked as expected (I can amend to remove the lock file if you want me to).

Finally, I tried to handle this as you do `file`, but if you want me to change something don't hesitate to ask! 

- [X] By including this repository in NUR I give permission to license the
content under the MIT license.