### PR TITLE
Remove yurrriq repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -647,10 +647,6 @@
             "github-contact": "ysndr",
             "url": "https://github.com/ysndr/nur-packages"
         },
-        "yurrriq": {
-            "github-contact": "yurrriq",
-            "url": "https://github.com/yurrriq/nur-packages"
-        },
         "zachcoyle": {
             "github-contact": "zachcoyle",
             "url": "https://github.com/zachcoyle/nur-packages"


### PR DESCRIPTION
I'm not maintaining https://github.com/yurrriq/nur-packages, as it's no longer useful to me, personally.

I'm pretty sure at least one person was using some darwin package or other from me at some point. Hopefully this doesn't cause too many problems. I'm happy to leave it in NUR. Just know that it's no longer going to be updated.

----

The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
