### PR TITLE
rename metadark -> kira-bruneau

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -302,6 +302,10 @@
             "github-contact": "kf5grd",
             "url": "https://github.com/kf5grd/nur-packages"
         },
+        "kira-bruneau": {
+            "github-contact": "kira-bruneau",
+            "url": "https://gitlab.com/kira-bruneau/nur-packages"
+        },
         "kmein": {
             "github-contact": "kmein",
             "submodules": true,
@@ -363,10 +367,6 @@
         "mcaju": {
             "github-contact": "CajuM",
             "url": "https://github.com/CajuM/nur-packages"
-        },
-        "metadark": {
-            "github-contact": "MetaDark",
-            "url": "https://github.com/metadark/nur-packages"
         },
         "mhuesch": {
             "github-contact": "mhuesch",


### PR DESCRIPTION
Also update my repo url to use my GitLab remote instead of my GitHub remote.

See related pull request in nixpkgs: NixOS/nixpkgs#124035

-------

The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.