### PR TITLE
add dan4ik repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -121,10 +121,10 @@
             "github-contact": "dali99",
             "url": "https://git.dodsorf.as/Dandellion/NUR"
         },
-	      "dan4ik605743": {
-	          "github-contact": "dan4ik605743",
-	          "url": "https://github.com/dan4ik605743/nur"
-	      },
+	    "dan4ik605743": {
+	        "github-contact": "dan4ik605743",
+	        "url": "https://github.com/dan4ik605743/nur"
+	    },
         "dawidsowa": {
             "github-contact": "dawidsowa",
             "url": "https://github.com/dawidsowa/nur-packages"

--- a/repos.json
+++ b/repos.json
@@ -117,14 +117,14 @@
             "submodules": true,
             "url": "https://github.com/cwyc/nur-packages"
         },
+        "dan4ik605743": {
+            "github-contact": "dan4ik605743",
+            "url": "https://github.com/dan4ik605743/nur"
+        },
         "dandellion": {
             "github-contact": "dali99",
             "url": "https://git.dodsorf.as/Dandellion/NUR"
         },
-	"dan4ik605743": {
-	    "github-contact": "dan4ik605743",
-	    "url": "https://github.com/dan4ik605743/nur"
-	},
         "dawidsowa": {
             "github-contact": "dawidsowa",
             "url": "https://github.com/dawidsowa/nur-packages"

--- a/repos.json
+++ b/repos.json
@@ -121,10 +121,10 @@
             "github-contact": "dali99",
             "url": "https://git.dodsorf.as/Dandellion/NUR"
         },
-	"dan4ik605743": {
-	    "github-contact": "dan4ik605743",
-	    "url": "https://github.com/dan4ik605743/nur"
-	},
+	    "dan4ik605743": {
+	        "github-contact": "dan4ik605743",
+	        "url": "https://github.com/dan4ik605743/nur"
+	    },
         "dawidsowa": {
             "github-contact": "dawidsowa",
             "url": "https://github.com/dawidsowa/nur-packages"

--- a/repos.json
+++ b/repos.json
@@ -121,6 +121,10 @@
             "github-contact": "dali99",
             "url": "https://git.dodsorf.as/Dandellion/NUR"
         },
+	      "dan4ik605743": {
+	          "github-contact": "dan4ik605743",
+	          "url": "https://github.com/dan4ik605743/nur"
+	      },
         "dawidsowa": {
             "github-contact": "dawidsowa",
             "url": "https://github.com/dawidsowa/nur-packages"

--- a/repos.json
+++ b/repos.json
@@ -121,10 +121,10 @@
             "github-contact": "dali99",
             "url": "https://git.dodsorf.as/Dandellion/NUR"
         },
-	    "dan4ik605743": {
-	        "github-contact": "dan4ik605743",
-	        "url": "https://github.com/dan4ik605743/nur"
-	    },
+	"dan4ik605743": {
+	    "github-contact": "dan4ik605743",
+	    "url": "https://github.com/dan4ik605743/nur"
+	},
         "dawidsowa": {
             "github-contact": "dawidsowa",
             "url": "https://github.com/dawidsowa/nur-packages"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- 

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)

- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
