### PR TITLE
repos: use NUR branch for kapack

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -305,6 +305,7 @@
             "url": "https://github.com/kampka/nix-packages"
         },
         "kapack": {
+            "branch": "NUR",
             "github-contact": "augu5te",
             "url": "https://github.com/oar-team/nur-kapack"
         },


### PR DESCRIPTION
Hi,

This commit states that the kapack repository should be fetched on kapack's `NUR` branch, not on kapack's `master` branch.
(I am a kapack maintainer, @augu5te can confim if needed.)

If we understood correctly, after this commit is merged future triggers such as `curl -XPOST "https://nur-update.herokuapp.com/update?repo=kapack"` should make NUR's automatic fetch/test/lock mechanism use kapack's `NUR` branch, is that right?

---
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
