### PR TITLE
repos: set file for kapack

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -305,6 +305,7 @@
             "url": "https://github.com/kampka/nix-packages"
         },
         "kapack": {
+            "file": "nur.nix",
             "github-contact": "augu5te",
             "url": "https://github.com/oar-team/nur-kapack"
         },


### PR DESCRIPTION
Hi,

This commit states that `nur.nix` should be used for the kapack repository, not `default.nix`.
(I am a kapack maintainer, @augu5te can confim if needed.)

---
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
