### PR TITLE
add VojtechStep repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -666,6 +666,10 @@
             "github-contact": "vdemeester",
             "url": "https://gitlab.com/vdemeester/home"
         },
+        "vojtechstep": {
+            "github-contact": "vojtechstep",
+            "url": "https://github.com/VojtechStep/vspkgs"
+        },
         "vroad": {
             "github-contact": "vroad",
             "url": "https://github.com/vroad/nur-packages"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [X] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [X] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
