### PR TITLE
switch to nix stable

### DIFF
--- a/ci/flake.lock
+++ b/ci/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1631561581,
-        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
+        "lastModified": 1637014545,
+        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
+        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1633329294,
-        "narHash": "sha256-0LpQLS4KMgxslMgmDHmxG/5twFlXDBW9z4Or1iOrCvU=",
+        "lastModified": 1637593665,
+        "narHash": "sha256-R7jKS7A+0tZS8qD5pBr1UFcMiTdsw5bfoxgXbYsoWhM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ee084c02040e864eeeb4cf4f8538d92f7c675671",
+        "rev": "98747f27ecfee70c8c97b195cbb94df80a074dda",
         "type": "github"
       },
       "original": {

--- a/ci/nur.nix
+++ b/ci/nur.nix
@@ -1,4 +1,4 @@
-{ buildPythonApplication, lib, nix-prefetch-git, git, nixUnstable, glibcLocales }:
+{ buildPythonApplication, lib, nix-prefetch-git, git, nix, glibcLocales }:
 
 buildPythonApplication {
   name = "nur";
@@ -7,7 +7,7 @@ buildPythonApplication {
   doCheck = false;
 
   makeWrapperArgs = [
-    "--prefix" "PATH" ":" "${lib.makeBinPath [ nix-prefetch-git git nixUnstable ]}"
+    "--prefix" "PATH" ":" "${lib.makeBinPath [ nix-prefetch-git git nix ]}"
     "--set" "LOCALE_ARCHIVE" "${glibcLocales}/lib/locale/locale-archive"
   ];
 }

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p bash -i bash -p python3Packages.mypy -p python3Packages.black -p python3Packages.flake8 -p nixUnstable
+#!nix-shell -p bash -i bash -p python3Packages.mypy -p python3Packages.black -p python3Packages.flake8 -p nix
 
 set -eux -o pipefail # Exit with nonzero exit code if anything fails
 

--- a/ci/update-nur-search.sh
+++ b/ci/update-nur-search.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p git -p nixUnstable -p bash -i bash
+#!nix-shell -p git -p nix -p bash -i bash
 
 set -eu -o pipefail # Exit with nonzero exit code if anything fails
 

--- a/ci/update-nur.sh
+++ b/ci/update-nur.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p git -p nixUnstable -p bash -i bash
+#!nix-shell -p git -p nix -p bash -i bash
 
 set -eu -o pipefail # Exit with nonzero exit code if anything fails
 


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
