### PR TITLE
remove kmein repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -347,11 +347,6 @@
             "github-contact": "kira-bruneau",
             "url": "https://gitlab.com/kira-bruneau/nur-packages"
         },
-        "kmein": {
-            "github-contact": "kmein",
-            "submodules": true,
-            "url": "https://github.com/kmein/nur-packages"
-        },
         "kolloch": {
             "github-contact": "kolloch",
             "url": "https://github.com/kolloch/nur-packages"

--- a/repos.json.lock
+++ b/repos.json.lock
@@ -21,8 +21,8 @@
             "url": "https://github.com/afreakk/mynixrepo"
         },
         "alarsyo": {
-            "rev": "ed7cacb3b4f243d4be2e0b1f2d0a51cc86a81ae4",
-            "sha256": "1hdj52jnyad1d1b5q99c8hsa5ngfwy8j2kvm6vg8h25cisd41fwb",
+            "rev": "196a9b97b7d4f407b2cb357466f08bc44e92fc7f",
+            "sha256": "15kms40phfq8b55vwqidzqqqyyslkdv0vx41j1jyyjv7jflsb16w",
             "url": "https://github.com/alarsyo/nixos-config"
         },
         "alwinb": {
@@ -415,12 +415,6 @@
             "rev": "c7b11edce7ea5438d927ff0335d8158175c1ecc6",
             "sha256": "0syfbaixym3cz9fwhyfgw6jawk3p6fpv17hsx6q880h2m2wyz92z",
             "url": "https://gitlab.com/kira-bruneau/nur-packages"
-        },
-        "kmein": {
-            "rev": "23fb0bd3a1735bf0a5b2fe2a41f1eb41d9a3f99f",
-            "sha256": "0y48dv39cpq4idrkcg3k38rys1lhjdg3l8n58dfnp081v23y62ng",
-            "submodules": true,
-            "url": "https://github.com/kmein/nur-packages"
         },
         "kolloch": {
             "rev": "606ac0cb71f21626c8ffd9f43a0b950d874696c5",


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.