### PR TITLE
ci: pin nix to 2.5.1

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,9 @@ jobs:
     - uses: cachix/install-nix-action@v16
       with:
         nix_path: nixpkgs=channel:nixos-unstable
+        # nix 2.6 breaks restrict-eval, when using the NIX_PATH
+        # see https://github.com/NixOS/nix/issues/5980
+        install_url: https://releases.nixos.org/nix/nix-2.5.1/install
         extra_nix_config: |
           experimental-features = nix-command flakes
     - run: ./ci/test.sh

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,6 +17,9 @@ jobs:
     - uses: cachix/install-nix-action@v16
       with:
         nix_path: nixpkgs=channel:nixos-unstable
+        # nix 2.6 breaks restrict-eval, when using the NIX_PATH
+        # see https://github.com/NixOS/nix/issues/5980
+        install_url: https://releases.nixos.org/nix/nix-2.5.1/install
         extra_nix_config: |
           experimental-features = nix-command flakes
     - name: update nur / nur-combined


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
