### PR TITLE
Remove unused nixpkgs entry in flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,27 +1,7 @@
 {
   "nodes": {
-    "nixpkgs": {
-      "info": {
-        "lastModified": 1590824667,
-        "narHash": "sha256-ut9bcUiG3LKIQtvLrhivTGqvjSP87fLlPssepQy7Ikg="
-      },
-      "locked": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "89e60f61ab6f09362433fd23370c590cd47e9c72",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "root": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      }
-    }
+    "root": {}
   },
   "root": "root",
-  "version": 5
+  "version": 7
 }


### PR DESCRIPTION
Can we get rid of the unused nixpkgs entry in `flake.lock`? With this change it would be possible to use this flake in a repl:

```
$ nix repl
nix-repl> pkgs = import <nixpkgs> { overlays = [ (builtins.getFlake "nur" ).outputs.overlay ]; }

nix-repl> pkgs.nur.repos
error: cannot write modified lock file of flake 'flake:nur' (use '--no-write-lock-file' to ignore)
```
