### PR TITLE
update misterio repo url

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -457,7 +457,7 @@
         "misterio": {
             "github-contact": "misterio77",
             "type": "sourcehut",
-            "url": "https://git.sr.ht/~misterio/nur-packages"
+            "url": "https://git.sr.ht/~misterio/nix-config"
         },
         "mmilata": {
             "github-contact": "mmilata",


### PR DESCRIPTION
Hey,

I've combined my NUR and Nix-config repos into one (its a lot easier to maintain and keep stuff in sync), here's a PR to update the URL.

Thanks!

---

The following points apply when adding a new repository to repos.json

- [X] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [X] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
