### PR TITLE
Rename astralbijection -> astridyu

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -60,9 +60,9 @@
             "github-contact": "artturin",
             "url": "https://github.com/Artturin/artturin-nur"
         },
-        "astralbijection": {
-            "github-contact": "astralbijection",
-            "url": "https://github.com/astralbijection/nur-packages"
+        "astridyu": {
+            "github-contact": "astridyu",
+            "url": "https://github.com/astridyu/nur-packages"
         },
         "awl-fcarza": {
             "github-contact": "francescocarzaniga",


### PR DESCRIPTION
This follows a Github username change.

The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
