### PR TITLE
nix-env: allow non-linux packages

### DIFF
--- a/ci/nur/index.py
+++ b/ci/nur/index.py
@@ -1,6 +1,7 @@
 import json
 import subprocess
 import sys
+import os
 from argparse import Namespace
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -73,9 +74,11 @@ callPackage (nur.repo-sources."%s" + "/%s") {}
     with NamedTemporaryFile(mode="w") as f:
         f.write(expr)
         f.flush()
+        env = os.environ.copy()
+        env.update(NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM="1")
         query_cmd = ["nix-env", "-qa", "*", "--json", "-f", str(f.name)]
         try:
-            out = subprocess.check_output(query_cmd)
+            out = subprocess.check_output(query_cmd, env=env)
         except subprocess.CalledProcessError:
             print(f"failed to evaluate {repo}", file=sys.stderr)
             return {}

--- a/ci/nur/update.py
+++ b/ci/nur/update.py
@@ -49,9 +49,8 @@ import {EVALREPO_PATH} {{
         # fmt: on
 
         logger.info(f"Evaluate repository {repo.name}")
-        proc = subprocess.Popen(
-            cmd, env=dict(PATH=os.environ["PATH"]), stdout=subprocess.DEVNULL
-        )
+        env = dict(PATH=os.environ["PATH"], NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM="1")
+        proc = subprocess.Popen(cmd, env=env, stdout=subprocess.DEVNULL)
         try:
             res = proc.wait(10)
         except subprocess.TimeoutExpired:


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
