### PR TITLE
update wolfangaukang repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -785,9 +785,8 @@
             "url": "https://github.com/WillPower3309/nur-packages"
         },
         "wolfangaukang": {
-            "branch": "main",
             "github-contact": "WolfangAukang",
-            "url": "https://codeberg.org/wolfangaukang/nur-pakoj.git"
+            "url": "https://codeberg.org/wolfangaukang/nix-agordoj.git"
         },
         "xddxdd": {
             "github-contact": "xddxdd",


### PR DESCRIPTION
Using my nix repository to host the packages plus removing the branch specification now that #439 is merged.

The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
