### PR TITLE
use --json instead of --xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,16 +352,17 @@ You can find out if your evaluation succeeded by checking the [latest build job]
 In your `nur-packages/` folder, run the [check evaluation](https://github.com/nix-community/nur-packages-template/blob/master/.github/workflows/build.yml) task
 
 ```sh
-nix-env -f . -qa \* --meta --xml \
+nix-env -f . -qa \* --meta \
   --allowed-uris https://static.rust-lang.org \
   --option restrict-eval true \
   --option allow-import-from-derivation true \
   --drv-path --show-trace \
   -I nixpkgs=$(nix-instantiate --find-file nixpkgs) \
-  -I ./
+  -I ./ \
+  --json | jq -r 'values | .[].name'
 ```
 
-On success, this shows an XML document with a list of your packages
+On success, this shows a list of your packages
 
 ### Git submodules
 


### PR DESCRIPTION
fixup to #446 

problems with xml ...

1. xml output is 10x slower than json (3 seconds vs 0.3 seconds)
2. some packages are missing in xml output. looks like a bug in nix, as both outputs should be same

```
# xml -> 8 packages
nix-env -f . -qa \* --meta --allowed-uris https://static.rust-lang.org \
  --option restrict-eval true --option allow-import-from-derivation true \
  --drv-path --show-trace -I nixpkgs=$(nix-instantiate --find-file nixpkgs) -I ./ \
  --xml | grep -F '<item ' | cut -d'"' -f2

archive-org-downloader
github-downloader
proftpd
gaupol
srtgen
rasterview
rpl
svn2github
```

```
# json -> 14 packages (expected)
nix-env -f . -qa \* --meta --allowed-uris https://static.rust-lang.org \
  --option restrict-eval true --option allow-import-from-derivation true \
  --drv-path --show-trace -I nixpkgs=$(nix-instantiate --find-file nixpkgs) -I ./ \
  --json | jq -r 'keys[]'

aether-server
archive-org-downloader
autosub-by-abhirooptalasila
gaupol
github-downloader
hazel-editor
proftpd
pyload
rasterview
recaf-bin
ricochet-refresh
rpl
srtgen
svn2github
```

missing in xml

```
aether-server
autosub-by-abhirooptalasila
hazel-editor
pyload
recaf-bin
ricochet-refresh
```

