### PR TITLE
add imsofi repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -299,6 +299,10 @@
             "github-contact": "immae",
             "url": "https://git.immae.eu/perso/Immae/Config/Nix/NUR.git"
         },
+        "imsofi": {
+            "github-contact": "imsofi",
+            "url": "https://github.com/imsofi/nur-pkgs"
+        },
         "instantos": {
             "github-contact": "con-f-use",
             "url": "https://github.com/instantOS/nix"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
