### PR TITLE
add fliegendewurst repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -241,6 +241,10 @@
             "github-contact": "neumantm",
             "url": "https://github.com/Fius/nur-packages"
         },
+        "fliegendewurst": {
+            "github-contact": "FliegendeWurst",
+            "url": "https://github.com/FliegendeWurst/nur-packages/"
+        },
         "foolnotion": {
             "github-contact": "foolnotion",
             "url": "https://github.com/foolnotion/nur-pkg"


### PR DESCRIPTION
- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
