### PR TITLE
flake.nix: add overlay less method to use `nixosModules.nur`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,5 +8,19 @@
         pkgs = prev;
       };
     };
+    nixosModules.nur = { lib, pkgs, ... }: {
+      options.nur = lib.mkOption {
+        type = lib.mkOptionType {
+          name = "nur";
+          description = "An instance of the Nix User repository";
+          check = builtins.isAttrs;
+        };
+        description = "Use this option to import packages from NUR";
+        default = import self {
+          nurpkgs = pkgs;
+          pkgs = pkgs;
+        };
+      };
+    };
   };
 }


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
