### PR TITLE
Revert "Revert "add bandithedoge repo""

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -72,6 +72,10 @@
             "github-contact": "balsoft",
             "url": "https://github.com/balsoft/nur-packages"
         },
+        "bandithedoge": {
+            "github-contact": "bandithedoge",
+            "url": "https://github.com/bandithedoge/nur-packages"
+        },
         "bb010g": {
             "github-contact": "bb010g",
             "url": "https://github.com/bb010g/nur-packages"


### PR DESCRIPTION
This reverts commit 95519a158d63e6d6bdb231d7c11d529a271c6b1e.

The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the
Nix Packages collection, merely to the package descriptions (i.e., Nix
expressions, build scripts, etc.).  It also might not apply to patches
included in Nixpkgs, which may be derivative works of the packages to
which they apply. The aforementioned artifacts are all covered by the
licenses of the respective packages.
