### PR TITLE
README: fix flake modules example

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ Instead use:
       # ...
       modules = let
         nur-modules = import nur {
-          nurpkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
+          nurpkgs = nixpkgs.legacyPackages.x86_64-linux;
+          pkgs = nixpkgs.legacyPackages.x86_64-linux;
         };
       in [
        { imports = [ nur-modules.repos.paul.modules.foo ]; }


### PR DESCRIPTION
Fix error:
```
error: NUR import call didn't receive a pkgs argument, but the evaluation of NUR's <...> repository requires it.

       This is either because
         - You're trying to use a package from that repository, but didn't pass a `pkgs` argument to the NUR import.
           In that case, refer to the installation instructions at https://github.com/nix-community/nur#installation on how to properly import NUR

         - You're trying to use a module/overlay from that repository, but it didn't properly declare their module.
           In that case, inform the maintainer of the repository: https://github.com/<...>
(use '--show-trace' to show detailed location information)
```