### PR TITLE
Add darkkirb repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -171,6 +171,10 @@
             "github-contact": "dali99",
             "url": "https://git.dodsorf.as/Dandellion/NUR"
         },
+        "darkkirb": {
+            "github-contact": "DarkKirb",
+            "url": "https://git.chir.rs/darkkirb/nix-packages"
+        },
         "dawidsowa": {
             "github-contact": "dawidsowa",
             "url": "https://github.com/dawidsowa/nur-packages"


### PR DESCRIPTION
This repository currently contains the following packages:

- Akkoma, and its pleroma and admin frontends, built from git, with patches for my personal instance
- matrix-media-repo built from git
- git versions of mautrix-signal and mautrix-telegram
- mautrix-discord and mautrix-whatsapp, also built from git
- a usually more updated version of papermc
- Plover with https://github.com/openstenoproject/plover/pull/1461#issuecomment-1065494960 applied (wayland support)
- a few plover plugins, latest pypi version
- KreativeKorp’s fonts
- Emoji for akkoma made by volpeon (https://volpeon.ink/)

The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
