### PR TITLE
Add nix-geht repository.

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -583,6 +583,10 @@
             "github-contact": "Jake-Gillberg",
             "url": "https://github.com/Jake-Gillberg/nix-data"
         },
+        "nix-geht": {
+            "github-contact": "vifino",
+            "url": "https://github.com/vifino/nix-geht"
+        },
         "nix-swift-packages": {
             "github-contact": "dduan",
             "url": "https://github.com/dduan/nix-swift-packages"


### PR DESCRIPTION
Contains only a vpp package, at the moment. But will probably contain much more in the future.

The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
