### PR TITLE
add rseops repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -727,6 +727,10 @@
             "github-contact": "robertodr",
             "url": "https://github.com/robertodr/nur-packages"
         },
+        "rseops": {
+            "github-contact": "vsoch",
+            "url": "https://github.com/rse-ops/nix"
+        },
         "rummik": {
             "github-contact": "rummik",
             "url": "https://gitlab.com/rummik/nixos/nur-packages"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the content under the MIT license.
