### PR TITLE
add freeflowuniverse & threefoldtech

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -269,6 +269,10 @@
             "github-contact": "fendse",
             "url": "https://github.com/fendse/nur"
         },
+        "freeflowuniverse": {
+            "github-contact": "freeflowuniverse",
+            "url": "https://github.com/freeflowuniverse/nur-packages"
+        },        
         "fgaz": {
             "github-contact": "fgaz",
             "url": "https://github.com/fgaz/nur-packages"
@@ -831,6 +835,10 @@
             "github-contact": "thilobillerbeck",
             "url": "https://github.com/thilobillerbeck/nur-packages"
         },
+        "threefoldtech": {
+            "github-contact": "threefoldtech",
+            "url": "https://github.com/threefoldtech/nur-packages"
+        },                     
         "tilpner": {
             "github-contact": "tilpner",
             "url": "https://github.com/tilpner/nur-packages"


### PR DESCRIPTION
add freeflowuniverse & threefoldtech

The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
