### PR TITLE
Interupt13 patch 1

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -609,7 +609,7 @@
         },
         "noneucat": {
             "github-contact": "INTERUPT13",
-            "url": "https://github.com/noneucat-updated-nur-packages"
+            "url": "https://github.com/INTERUPT13/noneucat-updated-nur-packages"
         },
         "novafacing": {
             "github-contact": "novafacing",

--- a/repos.json
+++ b/repos.json
@@ -608,8 +608,8 @@
             "url": "https://github.com/NNBnh/nur-packages"
         },
         "noneucat": {
-            "github-contact": "noneucat",
-            "url": "https://git.sr.ht/~noneucat/nur-packages"
+            "github-contact": "INTERUPT13",
+            "url": "https://github.com/noneucat-updated-nur-packages"
         },
         "novafacing": {
             "github-contact": "novafacing",

--- a/repos.json.lock
+++ b/repos.json.lock
@@ -952,8 +952,8 @@
             "url": "https://github.com/sigprof/nur-packages"
         },
         "sikmir": {
-            "rev": "8d5f26cebab28148f723ac83763f614884153845",
-            "sha256": "1pz3mmzcvz7fn1aw42ydqni82qg93vknrdmr7gbgmz8mmf7zs0p0",
+            "rev": "1acdab841cd7d7b24e1328b5ea789e49cbc1e420",
+            "sha256": "04b3yvl4r46gh8w6k107n8hbag5b0xzs7yw8xwh4ikiym38j26z9",
             "url": "https://github.com/sikmir/nur-packages"
         },
         "sky": {

--- a/repos.json.lock
+++ b/repos.json.lock
@@ -367,8 +367,8 @@
             "url": "https://github.com/bignaux/nur-packages"
         },
         "geonix": {
-            "rev": "63599c41800a99f116e96b1f3fa63a8ed9190a5e",
-            "sha256": "0dh6kpl7lm1ys0mycw9npq3xizwyci16y1mx679bvqvjdl5zg4p4",
+            "rev": "0766b9b813fab5c97cf9966df34adc275613f519",
+            "sha256": "0hjfg0dr6vc4gcq4dw1m6nv1y7i3227qsacsnz4al8y3ylyych8w",
             "url": "https://github.com/imincik/geonix"
         },
         "grafcube": {
@@ -554,8 +554,8 @@
             "url": "https://github.com/PhotonQuantum/nur-packages"
         },
         "linyinfeng": {
-            "rev": "20ca1be5223c8fa7fca9d8c3dee37c6c767376b8",
-            "sha256": "0q3m732xb27iyvmzs4kl3mjw9gfjbla2wj765v88sg5hk2s7y9pz",
+            "rev": "d927599e2aeb3b2ea9cd2298d244512e6ed765dd",
+            "sha256": "09dmfc356pqy7afh7lhz26yh8kdbw3875f6kcca3spj3wig5cwzw",
             "url": "https://github.com/linyinfeng/nur-packages"
         },
         "lourkeur": {
@@ -831,8 +831,8 @@
             "url": "https://github.com/pniedzwiedzinski/pnpkgs"
         },
         "pokon548": {
-            "rev": "f3e8f07f791f7c9623ec3017484dedd778a39fb2",
-            "sha256": "1m45k22nl0gz5qyx0p3zg61sl3cs0dv64d3clf9zcwkb3v3gyzl7",
+            "rev": "7eacddb8793b3722d1ed9bebcf40790cfe63efd7",
+            "sha256": "08qna234ffhvih6284ix0qggid1gjayh65kbx70yddlciy3kcg4p",
             "url": "https://github.com/pokon548/nur-packages"
         },
         "polykernel": {
@@ -1107,8 +1107,8 @@
             "url": "https://codeberg.org/wolfangaukang/nix-agordoj.git"
         },
         "xddxdd": {
-            "rev": "7bdc196e0cd631f05f10519997578009696ef697",
-            "sha256": "1j1pnk8ckk36jm513p7bs0ap6z6r9yabslmf2gzv9wmllliwwcfn",
+            "rev": "b5e48afdc2338fa9238b7a612696f41d9937b74c",
+            "sha256": "0l2k5f8nvsxr6rkw08y7lx0amvdm72wxra27rviyl1066ynw3iyj",
             "url": "https://github.com/xddxdd/nur-packages"
         },
         "xe": {


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
