### PR TITLE
enable submodules for blakat360

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -122,8 +122,8 @@
         },
         "blakat360": {
             "github-contact": "blakat360",
-            "url": "https://github.com/blakat360/nur-packages",
-            "submodules": true
+            "submodules": true,
+            "url": "https://github.com/blakat360/nur-packages"
         },
         "c0deaddict": {
             "github-contact": "c0deaddict",

--- a/repos.json
+++ b/repos.json
@@ -122,7 +122,8 @@
         },
         "blakat360": {
             "github-contact": "blakat360",
-            "url": "https://github.com/blakat360/nur-packages"
+            "url": "https://github.com/blakat360/nur-packages",
+            "submodules": true
         },
         "c0deaddict": {
             "github-contact": "c0deaddict",


### PR DESCRIPTION
I want to enable submodules for my nur-packages repo so that I can use flakes as packages.