### PR TITLE
Add thaumy repo

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -964,6 +964,10 @@
         "zsien": {
             "github-contact": "zsien",
             "url": "https://github.com/zsien/nur-packages"
+        },
+        "thaumy": {
+            "github-contact": "Thaumy",
+            "url": "https://github.com/Thaumy/nur-pkgs"
         }
     }
 }

--- a/repos.json
+++ b/repos.json
@@ -840,6 +840,10 @@
             "github-contact": "tboerger",
             "url": "https://github.com/tboerger/nur-packages"
         },
+        "thaumy": {
+            "github-contact": "Thaumy",
+            "url": "https://github.com/Thaumy/nur-pkgs"
+        },
         "thilobillerbeck": {
             "github-contact": "thilobillerbeck",
             "url": "https://github.com/thilobillerbeck/nur-packages"
@@ -964,10 +968,6 @@
         "zsien": {
             "github-contact": "zsien",
             "url": "https://github.com/zsien/nur-packages"
-        },
-        "thaumy": {
-            "github-contact": "Thaumy",
-            "url": "https://github.com/Thaumy/nur-pkgs"
         }
     }
 }


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
