### PR TITLE
Change own repository location

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -14,9 +14,9 @@
             "url": "https://gricad-gitlab.univ-grenoble-alpes.fr/Projets-INFO4/18-19/19/code"
         },
         "JayRovacsek": {
-            "file": "pkgs/default.nix",
+            "file": "packages/default.nix",
             "github-contact": "JayRovacsek",
-            "url": "https://github.com/JayRovacsek/nix-packages"
+            "url": "https://github.com/JayRovacsek/nix-config"
         },
         "ProducerMatt": {
             "github-contact": "ProducerMatt",


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [X] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [X] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
