### PR TITLE
add liyangau/nur-packages repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -487,6 +487,10 @@
             "github-contact": "linyinfeng",
             "url": "https://github.com/linyinfeng/nur-packages"
         },
+        "liyangau": {
+            "github-contact": "liyangau",
+            "url": "https://github.com/liyangau/nur-packages"
+        },
         "lourkeur": {
             "github-contact": "lourkeur",
             "url": "https://github.com/lourkeur/nur-expressions"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
