### PR TITLE
Remove JayRovacsek repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -13,11 +13,6 @@
             "type": "gitlab",
             "url": "https://gricad-gitlab.univ-grenoble-alpes.fr/Projets-INFO4/18-19/19/code"
         },
-        "JayRovacsek": {
-            "file": "packages/default.nix",
-            "github-contact": "JayRovacsek",
-            "url": "https://github.com/JayRovacsek/nix-config"
-        },
         "ProducerMatt": {
             "github-contact": "ProducerMatt",
             "url": "https://github.com/ProducerMatt/my-nur-pkgs"


### PR DESCRIPTION
Removing my repository as I want to move to a purely flake-based approach in package management & exposure

~The following points apply when adding a new repository to repos.json~

- [X] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
