### PR TITLE
add infinitivewitch repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -377,6 +377,10 @@
             "github-contact": "imsofi",
             "url": "https://github.com/imsofi/nur-pkgs"
         },
+        "infinitivewitch": {
+            "github-contact": "infinitivewitch",
+            "url": "https://github.com/infinitivewitch/nur-packages"
+        },
         "instantos": {
             "github-contact": "con-f-use",
             "url": "https://github.com/instantOS/nix"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [X] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [X] By including this repository in NUR I give permission to license the content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
