### PR TITLE
ftbwiki: Init

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -315,6 +315,10 @@
             "github-contact": "friedow",
             "url": "https://github.com/friedow/nur-packages"
         },
+        "ftbwiki": {
+            "github-contact": "tomodachi94",
+            "url": "https://github.com/tomodachi94/nur-ftbwiki"
+        },
         "genesis": {
             "github-contact": "bignaux",
             "url": "https://github.com/bignaux/nur-packages"


### PR DESCRIPTION
This will contain niche software for the [FTB Wiki](https://ftb.fandom.com). This software is not of public interest; it's only really used by FTB Wiki editors, but I (and some others) still would like to be able to use it Nix-style.

## Checklist

The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
