### PR TITLE
add 'file' in ataraxiasjel repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -103,6 +103,7 @@
             "url": "https://github.com/Artturin/artturin-nur"
         },
         "ataraxiasjel": {
+            "file": "pkgs/default.nix",
             "github-contact": "AtaraxiaSjel",
             "url": "https://github.com/AtaraxiaSjel/nur"
         },


### PR DESCRIPTION
I move default.nix in my nur repo to pkgs directory

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)