### PR TITLE
add arti5an repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -94,6 +94,10 @@
             "type": "sourcehut",
             "url": "https://git.sr.ht/~artemis/artenekoverlay"
         },
+        "arti5an": {
+            "github-contact": "arti5an",
+            "url": "https://github.com/arti5an/nur-packages"
+        },
         "artturin": {
             "github-contact": "artturin",
             "url": "https://github.com/Artturin/artturin-nur"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
