### PR TITLE
Show how to use modules on NixOS with flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,18 +118,22 @@ Instead use:
 
 ```nix
 {
-  inputs.nur.url = github:nix-community/NUR;
-
-  outputs = { self, nixpkgs, nur }: {
-    nixosConfigurations.myConfig = nixpkgs.lib.nixosSystem {
-      # ...
-      modules = let
-        nur-modules = import nur {
-          nurpkgs = nixpkgs.legacyPackages.x86_64-linux;
-          pkgs = nixpkgs.legacyPackages.x86_64-linux;
-        };
-      in [
-       { imports = [ nur-modules.repos.paul.modules.foo ]; }
+  inputs.nur.url = "github:nix-community/NUR";
+  outputs = { self, nixpkgs, nur }: rec {
+    nixosConfigurations.laptop = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        { nixpkgs.overlays = [ nur.overlay ]; }
+        ({ pkgs, ... }:
+          let
+            nur-no-pkgs = import nur {
+              nurpkgs = import nixpkgs { system = "x86_64-linux"; };
+            };
+          in {
+            imports = [ nur-no-pkgs.repos.iopq.modules.xraya  ];
+            services.xraya.enable = true;
+          })
+        #./configuration.nix or other imports here
       ];
     };
   };


### PR DESCRIPTION
This setup worked for me, I also added my working module for testing, you can change it to something lighter (a hello world module?)

The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
