### PR TITLE
add caarlos0, charmbracelet, and goreleaser repos

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -184,9 +184,17 @@
             "github-contact": "c0deaddict",
             "url": "https://github.com/c0deaddict/nur-packages"
         },
+        "caarlos0": {
+            "github-contact": "caarlos0",
+            "url": "https://github.com/caarlos0/nur"
+        },
         "chagra": {
             "github-contact": "chagra",
             "url": "https://github.com/ihebchagra/nur-packages"
+        },
+        "charmbracelet": {
+            "github-contact": "caarlos0",
+            "url": "https://github.com/charmbracelet/nur"
         },
         "chisui": {
             "github-contact": "chisui",
@@ -394,6 +402,10 @@
         "geonix": {
             "github-contact": "imincik",
             "url": "https://github.com/imincik/geonix"
+        },
+        "goreleaser": {
+            "github-contact": "caarlos0",
+            "url": "https://github.com/goreleaser/nur"
         },
         "grafcube": {
             "github-contact": "Grafcube",


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
