### PR TITLE
Add aprilthepink repo

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -17,6 +17,10 @@
             "github-contact": "Adamekka",
             "url": "https://github.com/Adamekka/nur-packages"
         },
+        "aprilthepink": {
+            "github-contact": "CutestNekoAqua",
+            "url": "https://github.com/CutestNekoAqua/nur-repo"
+        },
         "AsterisMono": {
             "github-contact": "AsterisMono",
             "url": "https://github.com/AsterisMono/nur-packages"

--- a/repos.json
+++ b/repos.json
@@ -17,10 +17,6 @@
             "github-contact": "Adamekka",
             "url": "https://github.com/Adamekka/nur-packages"
         },
-        "aprilthepink": {
-            "github-contact": "CutestNekoAqua",
-            "url": "https://github.com/CutestNekoAqua/nur-repo"
-        },
         "AsterisMono": {
             "github-contact": "AsterisMono",
             "url": "https://github.com/AsterisMono/nur-packages"
@@ -111,6 +107,10 @@
         "anthonyroussel": {
             "github-contact": "anthonyroussel",
             "url": "https://github.com/anthonyroussel/nur-packages"
+        },
+        "aprilthepink": {
+            "github-contact": "CutestNekoAqua",
+            "url": "https://github.com/CutestNekoAqua/nur-repo"
         },
         "arc": {
             "file": "nur.nix",


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
