### PR TITLE
Update README.md - fix grammatrical errors in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ option to a path relative to the repository root:
 
 ### Update NUR's lock file after updating your repository
 
-By default we only check for repository updates once a day with an automatic
+By default, we only check for repository updates once a day with an automatic
 github action to update our lock file `repos.json.lock`.
 To update NUR faster, you can use our service at https://nur-update.nix-community.org/
 after you have pushed an update to your repository, e.g.:
@@ -344,7 +344,7 @@ curl -XPOST https://nur-update.nix-community.org/update?repo=mic92
 Check out the [github page](https://github.com/nix-community/nur-update#nur-update-endpoint) for further details
 
 ### HELP! Why are my NUR packages not updating?
-With every build triggered via the URL hook all repositories will be evaluated.Only if the evaluation does not contain errors the repository revision for the user is updated. Typical evaluation errors are:
+With every build triggered via the URL hook, all repositories will be evaluated.Only if the evaluation does not contain errors the repository revision for the user is updated. Typical evaluation errors are:
 
 * Using a wrong license attribute in the metadata.
 * Using a builtin fetcher because it will cause access to external URLs during evaluation. Use pkgs.fetch* instead (i.e. instead of `builtins.fetchGit` use `pkgs.fetchgit`)


### PR DESCRIPTION
I have noticed some grammatical mistakes in **README** inside section "**Update NUR's lock file after updating your repository**" and "**HELP! Why are my NUR packages not updating?**"

"**By default we only**"  should be "**By default, we only**"

" ** via the URL hook all**"  should be " ** via the URL hook, all**"

Screenshot-

![Screenshot (147)](https://github.com/nix-community/NUR/assets/115995339/41fe51d8-2f2e-4a18-b757-ba940027dea2)
