### PR TITLE
add jeffguorg repository 

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -647,6 +647,10 @@
             "github-contact": "jbarthelmes",
             "url": "https://github.com/jbarthelmes/nur-packages"
         },
+        "jeffguorg": {
+            "github-contact": "jeffguorg",
+            "url": "https://github.com/jeffguorg/nur-packages"
+        },
         "jitterbug": {
             "github-contact": "JuniorIsAJitterbug",
             "url": "https://github.com/JuniorIsAJitterbug/nur-packages"
@@ -1392,10 +1396,6 @@
         "zsien": {
             "github-contact": "zsien",
             "url": "https://github.com/zsien/nur-packages"
-        },
-        "jeffguorg": {
-            "github-contact": "jeffguorg",
-            "url": "https://github.com/jeffguorg/nur-packages"
         }
     }
 }

--- a/repos.json
+++ b/repos.json
@@ -1392,6 +1392,10 @@
         "zsien": {
             "github-contact": "zsien",
             "url": "https://github.com/zsien/nur-packages"
+        },
+        "jeffguorg": {
+            "github-contact": "jeffguorg",
+            "url": "https://github.com/jeffguorg/nur-packages"
         }
     }
 }


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
