### PR TITLE
made it possible to use NUR with without overrides

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,14 @@
 {
   nurpkgs ? import <nixpkgs> { }, # For nixpkgs dependencies used by NUR itself
   # Dependencies to call NUR repos with
-  pkgs ? null,
+  # The override handles the case where NUR is installed via standalone channel or channel + override
+  pkgs ? (
+    import <nixpkgs> {
+      overrides = [
+        (final: prev: if prev ? nur then prev else { nur = ./. { pkgs = final; }; })
+      ];
+    }
+  ),
   repoOverrides ? { },
 }:
 


### PR DESCRIPTION
this means you can use it directly from a channel or via a nix repl in a local clone.

channels allow nicer management of version updates, and this allows NUR to be used easily in at the user-level.