### PR TITLE
add ona-li-toki-e-jan-Epiphany-tawa-mi repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -987,6 +987,10 @@
             "github-contact": "oluceps",
             "url": "https://github.com/oluceps/nur-pkgs"
         },
+        "ona-li-toki-e-jan-Epiphany-tawa-mi": {
+            "github-contact": "ona-li-toki-e-jan-Epiphany-tawa-mi",
+            "url": "https://github.com/ona-li-toki-e-jan-Epiphany-tawa-mi/epitaphpkgs"
+        },
         "ondt": {
             "github-contact": "ondt",
             "url": "https://github.com/ondt/nur-packages"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
