### PR TITLE
Add "nikpkgs" repo

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -940,6 +940,10 @@
             "github-contact": "lucacome",
             "url": "https://github.com/nginxinc/nur"
         },
+        "nikpkgs": {
+            "github-contact": "nikp123",
+            "url": "https://github.com/nikp123/nur-packages"
+        },
         "nim65s": {
             "github-contact": "nim65s",
             "url": "https://github.com/nim65s/nur-packages"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
None - I wrote all of those myself
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
