### PR TITLE
drop nltch repository for now

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -972,10 +972,6 @@
             "github-contact": "dduan",
             "url": "https://github.com/dduan/nix-swift-packages"
         },
-        "nltch": {
-            "github-contact": "nltch",
-            "url": "https://github.com/nl-tch/nur-packages"
-        },
         "nnb": {
             "github-contact": "NNBnh",
             "url": "https://github.com/NNBnh/nur-packages"


### PR DESCRIPTION
The repository started adding large binaries and git-lfs in https://github.com/NL-TCH/nur-packages/commit/7e3bddecbc24cafdac617da8b8104f8f85b752e8
both things we cannot have in NUR. As this is breaking the CI,
I will drop it for now.

cc @nl-tch