### PR TITLE
Added willbou1 to repos.json

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1373,6 +1373,10 @@
             "github-contact": "whs",
             "url": "https://github.com/whs/nix"
         },
+        "willbou1": {
+            "github-contact": "willbou1",
+            "url": "https://github.com/willbou1/nur-packages"
+        },
         "willpower3309": {
             "github-contact": "willpower3309",
             "url": "https://github.com/WillPower3309/nur-packages"
@@ -1428,10 +1432,6 @@
         "zsien": {
             "github-contact": "zsien",
             "url": "https://github.com/zsien/nur-packages"
-        },
-        "willbou1": {
-            "github-contact": "willbou1",
-            "url": "https://github.com/willbou1/nur-packages"
         }
     }
 }

--- a/repos.json
+++ b/repos.json
@@ -1428,6 +1428,10 @@
         "zsien": {
             "github-contact": "zsien",
             "url": "https://github.com/zsien/nur-packages"
+        },
+        "willbou1": {
+            "github-contact": "willbou1",
+            "url": "https://github.com/willbou1/nur-packages"
         }
     }
 }


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
