### PR TITLE
Add bhasherbel repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -229,6 +229,10 @@
             "github-contact": "berryp",
             "url": "https://github.com/berryp/nur-packages"
         },
+        "bhasherbel": {
+            "github-contact": "BhasherBEL",
+            "url": "https://github.com/bhasherbel/nur-packages"
+        },
         "bhipple": {
             "github-contact": "bhipple",
             "url": "https://github.com/bhipple/nur-packages"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [X] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [X] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
