### PR TITLE
Add Redrield/nurpkgs repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -75,6 +75,10 @@
             "github-contact": "ProducerMatt",
             "url": "https://github.com/ProducerMatt/my-nur-pkgs"
         },
+        "Redrield": {
+            "github-contact": "Redrield",
+            "url": "https://github.com/Redrield/nurpkgs"
+        },
         "Samuel-Martineau": {
             "github-contact": "Samuel-Martineau",
             "url": "https://github.com/Samuel-Martineau/nur-packages"
@@ -1151,10 +1155,6 @@
         "rconan": {
             "github-contact": "riconnon",
             "url": "https://gitlab.com/rconan/nix-packages"
-        },
-        "Redrield": {
-            "github-contact": "Redrield",
-            "url": "https://github.com/Redrield/nurpkgs"
         },
         "reedrw": {
             "github-contact": "reedrw",

--- a/repos.json
+++ b/repos.json
@@ -1152,6 +1152,10 @@
             "github-contact": "riconnon",
             "url": "https://gitlab.com/rconan/nix-packages"
         },
+        "Redrield": {
+            "github-contact": "Redrield",
+            "url": "https://github.com/Redrield/nurpkgs"
+        },
         "reedrw": {
             "github-contact": "reedrw",
             "url": "https://github.com/reedrw/nur-packages"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
