### PR TITLE
add qenya repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1148,6 +1148,10 @@
             "github-contact": "markuskowa",
             "url": "https://github.com/markuskowa/NixOS-QChem"
         },
+        "qenya": {
+            "github-contact": "qenya",
+            "url": "https://github.com/qenya/nur-packages"
+        },
         "qwbarch": {
             "github-contact": "qwbarch",
             "url": "https://github.com/qwbarch/nur-packages"

--- a/repos.json.lock
+++ b/repos.json.lock
@@ -1393,6 +1393,11 @@
             "sha256": "187yl39w1dg0c57bf0w6wi28w9b13z8wwdg0vb0lksfjb92qrdna",
             "url": "https://github.com/markuskowa/NixOS-QChem"
         },
+        "qenya": {
+            "rev": "5d897adb87a01a5ef8528f04f6aff1fe5e6fc13c",
+            "sha256": "11fbzn8y7gwfw4297fqyd0wdgm5g1v82xy5w6acxws3i1xbvbiwh",
+            "url": "https://github.com/qenya/nur-packages"
+        },
         "qwbarch": {
             "rev": "d25c6522d720e02be08fd358e7e493dbe0493096",
             "sha256": "0sjkwws1qab1930ab0bavmri3h3ss6cgas73i6qay8qf5z1q07sz",


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
