### PR TITLE
docs: add a simple example for using a single package in a devshell

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,35 @@ for its content.
 ***NUR does not check the repository for malicious content on a regular basis
 and it is recommended to check the expressions before installing them.***
 
+### Using a single package in a devshell
+
+This simple example demostrates how to add a single package from nur to a devshell defined in a flake.nix.
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    nur.url = "github:nix-community/NUR";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, nur }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ nur.overlay ];
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = [ pkgs.nur.repos.mic92.hello-nur ];
+        };
+      }
+    );
+}
+```
+
 ### Using the flake in NixOS
 
 Using overlays and modules from NUR in your configuration is fairly straight forward.


### PR DESCRIPTION
I was trying to add a single package from nur to a devshell, but it wasn't immediately clear to me how to do so. This PR demostrates adds a simple example for that use case.

---

The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
      content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
