### PR TITLE
Fix macos evaluation

### DIFF
--- a/ci/nur/eval.py
+++ b/ci/nur/eval.py
@@ -29,10 +29,11 @@ import {EVALREPO_PATH} {{
 """
             )
 
+        canonicalized_eval_path = eval_path.resolve()
         # fmt: off
         cmd = [
             "nix-env",
-            "-f", str(eval_path),
+            "-f", str(canonicalized_eval_path),
             "-qa", "*",
             "--meta",
             "--xml",
@@ -43,7 +44,7 @@ import {EVALREPO_PATH} {{
             "--show-trace",
             "-I", f"nixpkgs={nixpkgs_path()}",
             "-I", str(repo_path),
-            "-I", str(eval_path),
+            "-I", str(canonicalized_eval_path),
             "-I", str(EVALREPO_PATH),
         ]
         # fmt: on


### PR DESCRIPTION
fixes #438 

path needs to be resolved from /tmp/<tmpdir>/default.nix to /private/tmp/<tmpdir>/default.nix on macos to pass restrict-eval = true