### PR TITLE
bin/nur: update shebang to include python3Packages.distutils

### DIFF
--- a/bin/nur
+++ b/bin/nur
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p python3 -p nix-prefetch-git -p nix -i python3
+#!nix-shell -p python3 -p nix-prefetch-git -p nix -i python3 -p python3Packages.distutils
 import sys
 import os
 


### PR DESCRIPTION
Running `bin/nur update` as suggested in the README currently fails because distutils can be found (under current nixos-unstable).

```
❯ ./bin/nur update
Traceback (most recent call last):
  File "/home/mrene/dev/NUR/./bin/nur", line 9, in <module>
    from nur import main
  File "/home/mrene/dev/NUR/ci/nur/__init__.py", line 6, in <module>
    from .combine import combine_command
  File "/home/mrene/dev/NUR/ci/nur/combine.py", line 6, in <module>
    from distutils.dir_util import copy_tree
ModuleNotFoundError: No module named 'distutils'
```

Adding the package to the shebang nix-shell invocation allows it to run.

Fixes #747