### PR TITLE
Remove dependency on deprecated distutils package

### DIFF
--- a/bin/nur
+++ b/bin/nur
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p python3 -p nix-prefetch-git -p nix -i python3 -p python3Packages.distutils
+#!nix-shell -p python3 -p nix-prefetch-git -p nix -i python3
 import sys
 import os
 

--- a/ci/nur/combine.py
+++ b/ci/nur/combine.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import subprocess
 from argparse import Namespace
-from distutils.dir_util import copy_tree
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Dict, List, Optional
@@ -51,7 +50,7 @@ def commit_repo(repo: Repo, message: str, path: Path) -> Repo:
     assert tmp is not None
 
     try:
-        copy_tree(repo_source(repo.name), tmp.name, preserve_symlinks=1)
+        shutil.copytree(repo_source(repo.name), tmp.name, preserve_symlinks=1)
         shutil.rmtree(repo_path, ignore_errors=True)
         os.rename(tmp.name, repo_path)
         tmp = None
@@ -160,7 +159,7 @@ def setup_combined() -> None:
         write_json_file(dict(repos={}), manifest_path)
 
     manifest_lib = "lib"
-    copy_tree(str(ROOT.joinpath("lib")), manifest_lib, preserve_symlinks=1)
+    shutil.copytree(str(ROOT.joinpath("lib")), manifest_lib, preserve_symlinks=1)
     default_nix = "default.nix"
     shutil.copy(ROOT.joinpath("default.nix"), default_nix)
 

--- a/ci/nur/combine.py
+++ b/ci/nur/combine.py
@@ -50,7 +50,7 @@ def commit_repo(repo: Repo, message: str, path: Path) -> Repo:
     assert tmp is not None
 
     try:
-        shutil.copytree(repo_source(repo.name), tmp.name, preserve_symlinks=1)
+        shutil.copytree(repo_source(repo.name), tmp.name, symlinks=True)
         shutil.rmtree(repo_path, ignore_errors=True)
         os.rename(tmp.name, repo_path)
         tmp = None
@@ -159,7 +159,7 @@ def setup_combined() -> None:
         write_json_file(dict(repos={}), manifest_path)
 
     manifest_lib = "lib"
-    shutil.copytree(str(ROOT.joinpath("lib")), manifest_lib, preserve_symlinks=1)
+    shutil.copytree(str(ROOT.joinpath("lib")), manifest_lib, symlinks=True)
     default_nix = "default.nix"
     shutil.copy(ROOT.joinpath("default.nix"), default_nix)
 


### PR DESCRIPTION
This pull removes the `bin/nur` command's dependency on `distutils`, which has been [deprecated since Python 3.10](https://docs.python.org/3.10/whatsnew/3.10.html#distutils-deprecated) and was [removed in Python 3.12](https://docs.python.org/3.12/whatsnew/3.12.html#distutils).

I was working on adding [my repository](https://github.com/Rhys-T/nur-packages) to repos.json, but when I got to the `bin/nur` step, I got this error:

```
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'shell'
         whose name attribute is located at /nix/store/xz92w26jxw11s3z9bysc5pdm78pj0y14-nixpkgs/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:336:7

       … while evaluating attribute 'buildInputs' of derivation 'shell'

         at /nix/store/xz92w26jxw11s3z9bysc5pdm78pj0y14-nixpkgs/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:383:7:

          382|       depsHostHost                = elemAt (elemAt dependencies 1) 0;
          383|       buildInputs                 = elemAt (elemAt dependencies 1) 1;
             |       ^
          384|       depsTargetTarget            = elemAt (elemAt dependencies 2) 0;

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: Package ‘python3.12-jaraco-path-3.7.1’ in /nix/store/xz92w26jxw11s3z9bysc5pdm78pj0y14-nixpkgs/nixpkgs/pkgs/development/python-modules/jaraco-path/default.nix:30 is marked as broken, refusing to evaluate.

       a) To temporarily allow broken packages, you can use an environment variable
          for a single invocation of the nix tools.

            $ export NIXPKGS_ALLOW_BROKEN=1

          Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
                then pass `--impure` in order to allow use of environment variables.

       b) For `nixos-rebuild` you can set
         { nixpkgs.config.allowBroken = true; }
       in configuration.nix to override this.

       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allowBroken = true; }
       to ~/.config/nixpkgs/config.nix.
```

Apparently `distutils` ends up depending on [`jaraco-path`](https://github.com/jaraco/path), which isn't currently building on Darwin because it can't find PyObjC. As a result, I can't actually run the current `bin/nur` on macOS.

The only thing `bin/nur` seems to use `distutils` for is the `copy_tree` function, which seems to have been replaced by `shutils.copytree`. I removed all references to `distutils` and swapped that function in, and so far it seems to be working correctly.