### PR TITLE
add Rhys-T repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -91,6 +91,10 @@
             "github-contact": "Redrield",
             "url": "https://github.com/Redrield/nurpkgs"
         },
+        "Rhys-T": {
+            "github-contact": "Rhys-T",
+            "url": "https://github.com/Rhys-T/nur-packages"
+        },
         "Samuel-Martineau": {
             "github-contact": "Samuel-Martineau",
             "url": "https://github.com/Samuel-Martineau/nur-packages"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
    **Note**: I _have_ run `./bin/nur format-manifest` and `./bin/nur update`, but only with the changes in #762 (because I can't run `bin/nur` on macOS otherwise), which is why this is still a draft.
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
