### PR TITLE
ci/nur/combine.py: Try to fix `File exists: 'lib'` error

### DIFF
--- a/ci/nur/combine.py
+++ b/ci/nur/combine.py
@@ -50,7 +50,9 @@ def commit_repo(repo: Repo, message: str, path: Path) -> Repo:
     assert tmp is not None
 
     try:
-        shutil.copytree(repo_source(repo.name), tmp.name, symlinks=True)
+        shutil.copytree(
+            repo_source(repo.name), tmp.name, symlinks=True, dirs_exist_ok=True
+        )
         shutil.rmtree(repo_path, ignore_errors=True)
         os.rename(tmp.name, repo_path)
         tmp = None
@@ -159,7 +161,9 @@ def setup_combined() -> None:
         write_json_file(dict(repos={}), manifest_path)
 
     manifest_lib = "lib"
-    shutil.copytree(str(ROOT.joinpath("lib")), manifest_lib, symlinks=True)
+    shutil.copytree(
+        str(ROOT.joinpath("lib")), manifest_lib, symlinks=True, dirs_exist_ok=True
+    )
     default_nix = "default.nix"
     shutil.copy(ROOT.joinpath("default.nix"), default_nix)
 


### PR DESCRIPTION
Followup to #762.

I don't know how I thought my changes in #762 were working on my machine. I really did try to test it, but I just noticed that the last couple of `update_nur` jobs failed with this error:
```
Traceback (most recent call last):
  File "/nix/store/jixljq3pr9zfyxvn1bz4r7h49awh00lc-nur/bin/.nur-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/jixljq3pr9zfyxvn1bz4r7h49awh00lc-nur/lib/python3.10/site-packages/nur/__init__.py", line 63, in main
    args.func(args)
  File "/nix/store/jixljq3pr9zfyxvn1bz4r7h49awh00lc-nur/lib/python3.10/site-packages/nur/combine.py", line 175, in combine_command
    setup_combined()
  File "/nix/store/jixljq3pr9zfyxvn1bz4r7h49awh00lc-nur/lib/python3.10/site-packages/nur/combine.py", line 162, in setup_combined
    shutil.copytree(str(ROOT.joinpath("lib")), manifest_lib, symlinks=True)
  File "/nix/store/412d25bdawy2idxfpnis8vjcm8cz2ag7-python3-3.10.11/lib/python3.10/shutil.py", line 559, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
  File "/nix/store/412d25bdawy2idxfpnis8vjcm8cz2ag7-python3-3.10.11/lib/python3.10/shutil.py", line 457, in _copytree
    os.makedirs(dst, exist_ok=dirs_exist_ok)
  File "/nix/store/412d25bdawy2idxfpnis8vjcm8cz2ag7-python3-3.10.11/lib/python3.10/os.py", line 225, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: 'lib'
```
I _think_ this pull is the correct fix - passing `dirs_exist_ok=True` should make `shutil.copytree` overwrite existing files and reuse existing directories, mimicking its `distutils` counterpart more closely. But I clearly don't know how to test it properly. Can you offer any guidance on this, so I can avoid causing any more problems like this in the future?

Sorry for breaking things.