### PR TITLE
Revert "Merge pull request #762 from Rhys-T/remove-distutils"

### DIFF
--- a/bin/nur
+++ b/bin/nur
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p python3 -p nix-prefetch-git -p nix -i python3
+#!nix-shell -p python3 -p nix-prefetch-git -p nix -i python3 -p python3Packages.distutils
 import sys
 import os
 

--- a/ci/nur/combine.py
+++ b/ci/nur/combine.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import subprocess
 from argparse import Namespace
+from distutils.dir_util import copy_tree
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Dict, List, Optional
@@ -50,9 +51,7 @@ def commit_repo(repo: Repo, message: str, path: Path) -> Repo:
     assert tmp is not None
 
     try:
-        shutil.copytree(
-            repo_source(repo.name), tmp.name, symlinks=True, dirs_exist_ok=True
-        )
+        copy_tree(repo_source(repo.name), tmp.name, preserve_symlinks=1)
         shutil.rmtree(repo_path, ignore_errors=True)
         os.rename(tmp.name, repo_path)
         tmp = None
@@ -161,9 +160,7 @@ def setup_combined() -> None:
         write_json_file(dict(repos={}), manifest_path)
 
     manifest_lib = "lib"
-    shutil.copytree(
-        str(ROOT.joinpath("lib")), manifest_lib, symlinks=True, dirs_exist_ok=True
-    )
+    copy_tree(str(ROOT.joinpath("lib")), manifest_lib, preserve_symlinks=1)
     default_nix = "default.nix"
     shutil.copy(ROOT.joinpath("default.nix"), default_nix)
 


### PR DESCRIPTION
Nothing I do seems to fix the new `shutils`-based version, so I'm putting everything back how it was, to at least get it working on Linux again and un-break the actions.

I am so sorry for all of this. I know this is the last thing you need right now. The instructions for adding a repository wanted me to run `bin/nur` commands, and I wanted to be able to honestly say I had done so before I submitted my repo, but clearly I don't understand the code well enough to fix it myself.