### PR TITLE
add wwmoraes repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1498,6 +1498,10 @@
             "github-contact": "WolfangAukang",
             "url": "https://codeberg.org/wolfangaukang/nix-agordoj.git"
         },
+        "wwmoraes": {
+            "github-contact": "wwmoraes",
+            "url": "https://github.com/wwmoraes/nurpkgs"
+        },
         "xddxdd": {
             "github-contact": "xddxdd",
             "url": "https://github.com/xddxdd/nur-packages"

--- a/repos.json.lock
+++ b/repos.json.lock
@@ -1824,6 +1824,11 @@
             "sha256": "1i3w5iqs92mdm4wxzjcp1ynaqsd06saphdsibmm5vlr9ddq2c7yx",
             "url": "https://codeberg.org/wolfangaukang/nix-agordoj.git"
         },
+        "wwmoraes": {
+            "rev": "43ccaa3ecbdf514f25dff66e4916222dbc2bc7fa",
+            "sha256": "0i48z2fg467645l1xx1qiz9xs5knp5g90419hdx9qd2czpr62ca2",
+            "url": "https://github.com/wwmoraes/nurpkgs"
+        },
         "xddxdd": {
             "rev": "32a5830f36dfc3e6be5fe2f3f233138aaec36177",
             "sha256": "0fh1pkswc93f1wn0zqzmaj3fnw0pqvz5gyv3i2v73w85y72v32sx",


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
