### PR TITLE
.mergify.yml: Update mergify configuration due to rename

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,10 +2,7 @@ queue_rules:
   - name: default
     merge_conditions:
       - check-success=tests
-defaults:
-  actions:
-    queue:
-      merge_method: rebase
+    merge_method: rebase
 pull_request_rules:
   - name: merge using the merge queue
     conditions:


### PR DESCRIPTION
From mergify's summary:

The configuration uses the deprecated merge_method attribute of the queue action in one or more pull_request_rules. It must now be used under the queue_rules configuration.

This option will be removed on January 31st, 2025.

For more information: https://docs.mergify.com/configuration/file-format/#queue-rules