### PR TITLE
pyproject.toml: Move relevant pyproject entries into lint subsection

### DIFF
--- a/ci/pyproject.toml
+++ b/ci/pyproject.toml
@@ -2,8 +2,8 @@
 target-version = "py311"
 line-length = 88
 
-select = ["E", "F", "I"]
-ignore = ["E501"]
+lint.select = ["E", "F", "I"]
+lint.ignore = ["E501"]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
According to `ruff check .`:

warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'