### PR TITLE
Flake-ify NUR

### DIFF
--- a/ci/update-nur.sh
+++ b/ci/update-nur.sh
@@ -19,6 +19,8 @@ git clone \
 
 nix run "${DIR}#" -- combine nur-combined
 
+nix flake update nixpkgs
+
 if [[ -z "$(git diff --exit-code)" ]]; then
   echo "No changes to the output on this push; exiting."
 else

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,68 @@
 {
   "nodes": {
-    "root": {}
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733212471,
+        "narHash": "sha256-M1+uCoV5igihRfcUKrr1riygbe73/dzNnzPsmaLCmpo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "55d15ad12a74eb7d4646254e13638ad0c4128776",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733222881,
+        "narHash": "sha256-JIPcz1PrpXUCbaccEnrcUS8jjEb/1vJbZz5KkobyFdM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "49717b5af6f80172275d47a418c9719a31a78b53",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
   },
   "root": "root",
   "version": 7

--- a/repos.json
+++ b/repos.json
@@ -111,10 +111,6 @@
             "github-contact": "YisuiDenghua",
             "url": "https://github.com/YisuiDenghua/nur-apps"
         },
-        "aacebedo": {
-            "github-contact": "aacebedo",
-            "url": "https://github.com/aacebedo/nur-packages"
-        },
         "aaqaishtyaq": {
             "github-contact": "aaqaishtyaq",
             "url": "https://github.com/aaqaishtyaq/nur-packages"


### PR DESCRIPTION
This has a similar rationale to https://github.com/nix-community/NUR/pull/677

This breaks anything that depends on the previous flake behavior, but should mean that NUR is easier to use and uses the standard flake attributes.

I'll leave this open for at least 48 hours in order to receive feedback before merging.