### PR TITLE
add nix-ros-overlay as repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1297,6 +1297,10 @@
             "github-contact": "robinovitch61",
             "url": "https://github.com/robinovitch61/nur-packages"
         },
+        "ros": {
+            "github-contact": "Pandapip1",
+            "url": "https://github.com/lopsided98/nix-ros-overlay"
+        },
         "rseops": {
             "github-contact": "vsoch",
             "url": "https://github.com/rse-ops/nix"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [X] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.
  - Permission cannot be granted, as I do not own the code. However, the repository is under the Apache-2.0 license, which is MIT-compatible.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
