### PR TITLE
fix: attribute 'throw' missing

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,8 +31,8 @@
       ) nixpkgs.lib.platforms.all;
       flake = {
         overlay = lib.warn "nur.overlay has been replaced by nur.overlays.default" overlay; # Added 2024-12-06
-        nixosModules.nur = lib.throw "nur.nixosModules.nur has been replaced by nur.modules.nixos.default"; # Added 2024-12-06
-        hmModules.nur = lib.throw "nur.hmModules.nur has been replaced by nur.modules.home-manager.default"; # Added 2024-12-06
+        nixosModules.nur = builtins.throw "nur.nixosModules.nur has been replaced by nur.modules.nixos.default"; # Added 2024-12-06
+        hmModules.nur = builtins.throw "nur.hmModules.nur has been replaced by nur.modules.home-manager.default"; # Added 2024-12-06
 
         overlays = {
           default = overlay;


### PR DESCRIPTION
```
       error: attribute 'throw' missing
       at /nix/store/bbfa2wvd0svlf0nlw78llkzv8w726vkv-source/flake.nix:34:28:
           33|         overlay = lib.warn "nur.overlay has been replaced by nur.overlays.default" overlay; # Added 2024-12-06
           34|         nixosModules.nur = lib.throw "nur.nixosModules.nur has been replaced by nur.modules.nixos.default"; # Added 2024-12-06
             |                            ^
           35|         hmModules.nur = lib.throw "nur.hmModules.nur has been replaced by nur.modules.home-manager.default"; # Added 2024-12-06
       Did you mean throwIf?
```

Have no idea why `lib.throw` doesn't point to `builtins.throw`, but the thing is that `lib.throw` doesn't exist, so we have to use `builtins.throw`

https://noogle.dev/f/lib/throw