### PR TITLE
Add mh0386 repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1,5 +1,9 @@
 {
     "repos": {
+        "MH0386": {
+            "github-contact": "MH0386",
+            "url": "https://github.com/MH0386/nurpkgs"
+        },
         "0x4A6F": {
             "github-contact": "0x4A6F",
             "url": "https://github.com/0x4A6F/nur-packages"

--- a/repos.json
+++ b/repos.json
@@ -1,9 +1,5 @@
 {
     "repos": {
-        "MH0386": {
-            "github-contact": "MH0386",
-            "url": "https://github.com/MH0386/nurpkgs"
-        },
         "0x4A6F": {
             "github-contact": "0x4A6F",
             "url": "https://github.com/0x4A6F/nur-packages"
@@ -74,6 +70,10 @@
         "LuisChDev": {
             "github-contact": "LuisChDev",
             "url": "https://github.com/LuisChDev/nur-packages"
+        },
+        "MH0386": {
+            "github-contact": "MH0386",
+            "url": "https://github.com/MH0386/nurpkgs"
         },
         "MtFBella109": {
             "github-contact": "MtFBella109",


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
