### PR TITLE
Remove kugland from repos.json.lock

### DIFF
--- a/repos.json.lock
+++ b/repos.json.lock
@@ -1064,12 +1064,6 @@
             "submodules": true,
             "url": "https://github.com/kreisys/nur-packages"
         },
-        "kugland": {
-            "rev": "d5af1b571d2e1cd563d1f52f993eef5eda021696",
-            "sha256": "1xnsmib09dxdqwxfcjp8pzpflvqkjpvcpf7r44089svhpcj1pdgg",
-            "submodules": true,
-            "url": "https://github.com/kugland/nur-packages"
-        },
         "lambdadog": {
             "rev": "222127489b9b2c89d68ca06e2f3c8f8bace0f65e",
             "sha256": "07v9sim0a4xc5m1v6rrh9mzml70ps9cm494asrj80q3bxmyc16ra",


### PR DESCRIPTION
The automatic update should then pick up the force push

CC @kugland

The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [ ] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
