### PR TITLE
Fix exclusion criteria for update job

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,7 +14,7 @@ jobs:
   update_nur:
     runs-on: ubuntu-latest
     # Don't trigger when the last push was done by a bot
-    if: github.event_name != 'push' || endsWith(github.actor, '[bot]')
+    if: github.event_name != 'push' || !endsWith(github.actor, '[bot]')
     steps:
     - id: get_workflow_token
       uses: peter-murray/workflow-application-token-action@v4.0.1


### PR DESCRIPTION
I accidentally had it only update on push when the bot pushed it, instead of only updating when the pusher _wasn't_ the bot.