### PR TITLE
Re-add mipmip repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1041,6 +1041,11 @@
             "github-contact": "minion3665",
             "url": "https://github.com/minion3665/nurpkgs"
         },
+        "mipmip": {
+            "file": "pkgs/default.nix",
+            "github-contact": "mipmip",
+            "url": "https://github.com/mipmip/nixos"
+        },
         "misterio": {
             "github-contact": "misterio77",
             "type": "sourcehut",


### PR DESCRIPTION
Re-adds the removed mipmip repository now that the live AWS key has been pulled.