### PR TITLE
Use builtin fetchers to prevent importing from derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@
   pkgs ? (
     import <nixpkgs> {
       overrides = [
-        (final: prev: if prev ? nur then prev else { nur = ./. { pkgs = final; }; })
+        (final: prev: if prev ? nur then prev else { nur = import ./. { pkgs = final; }; })
       ];
     }
   ),
@@ -28,7 +28,8 @@ let
         lockedRevisions
         lib
         ;
-      inherit (nurpkgs) fetchgit fetchzip;
+      fetchgit = builtins.fetchGit or nurpkgs.fetchgit;
+      fetchzip = builtins.fetchTarball or nurpkgs.fetchzip;
     };
 
   createRepo =

--- a/lib/repoSource.nix
+++ b/lib/repoSource.nix
@@ -47,6 +47,14 @@ else if (lib.hasPrefix "https://gitlab.com" attr.url || type == "gitlab") && !su
 else
   fetchgit {
     inherit (attr) url;
-    inherit (revision) rev sha256;
-    fetchSubmodules = submodules;
+    inherit (revision) rev;
   }
+  // (
+    if fetchgit == builtins.fetchGit or null then
+      { inherit submodules; }
+    else
+      {
+        inherit (revision) sha256;
+        fetchSubmodules = submodules;
+      }
+  )


### PR DESCRIPTION
The builtin fetchers run at eval time, which should prevent importing from derivation.