### PR TITLE
add trev repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1630,6 +1630,10 @@
             "github-contact": "ToyVo",
             "url": "https://github.com/ToyVo/nur-packages"
         },
+        "trev": {
+            "github-contact": "spotdemo4",
+            "url": "https://github.com/spotdemo4/nur"
+        },
         "trevorriles": {
             "github-contact": "trevorriles",
             "url": "https://github.com/trevorriles/nur-packages"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [x] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

Additionally, the following points are recommended:

- [x] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [x] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [x] `meta.license`, even for free packages
  - [x] `meta.homepage`, for tracking and deduplication
  - [x] `meta.mainProgram`, so that `nix run` works correctly
 
---

Does [bobgen](https://github.com/spotdemo4/nur/blob/main/pkgs/bobgen/default.nix) need a meta.mainProgram? In the [docs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md) it says:
> Packages like e2fsprogs that have multiple executables, none of which can be considered the main program, should not set meta.mainProgram.

I don't really consider any of the executables to be the "main" program. It depends on what database you're working with, or if you're just using sql files directly
