### PR TITLE
Revert "Use builtin fetchers to prevent importing from derivation"

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@
   pkgs ? (
     import <nixpkgs> {
       overrides = [
-        (final: prev: if prev ? nur then prev else { nur = import ./. { pkgs = final; }; })
+        (final: prev: if prev ? nur then prev else { nur = ./. { pkgs = final; }; })
       ];
     }
   ),
@@ -28,8 +28,7 @@ let
         lockedRevisions
         lib
         ;
-      fetchgit = builtins.fetchGit or nurpkgs.fetchgit;
-      fetchzip = builtins.fetchTarball or nurpkgs.fetchzip;
+      inherit (nurpkgs) fetchgit fetchzip;
     };
 
   createRepo =

--- a/lib/repoSource.nix
+++ b/lib/repoSource.nix
@@ -47,14 +47,6 @@ else if (lib.hasPrefix "https://gitlab.com" attr.url || type == "gitlab") && !su
 else
   fetchgit {
     inherit (attr) url;
-    inherit (revision) rev;
+    inherit (revision) rev sha256;
+    fetchSubmodules = submodules;
   }
-  // (
-    if fetchgit == builtins.fetchGit or null then
-      { inherit submodules; }
-    else
-      {
-        inherit (revision) sha256;
-        fetchSubmodules = submodules;
-      }
-  )


### PR DESCRIPTION
Reverts nix-community/NUR#907

See https://github.com/nix-community/NUR/issues/916

CC @ccicnce113424