### PR TITLE
Reapply: use builtin fetchers to prevent importing from derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@
   pkgs ? (
     import <nixpkgs> {
       overrides = [
-        (final: prev: if prev ? nur then prev else { nur = ./. { pkgs = final; }; })
+        (final: prev: if prev ? nur then prev else { nur = import ./. { pkgs = final; }; })
       ];
     }
   ),
@@ -19,6 +19,22 @@ let
   inherit (nurpkgs) lib;
 
   repoSource =
+    name: attr:
+    import ./lib/repoSource.nix {
+      inherit
+        name
+        attr
+        manifest
+        lockedRevisions
+        lib
+        ;
+      fetchgit = builtins.fetchGit or nurpkgs.fetchgit;
+      fetchzip = builtins.fetchTarball or nurpkgs.fetchzip;
+    };
+
+  # https://github.com/nix-community/NUR/issues/916
+  # Use Nixpkgs fetchers in repo-sources for compatibility with ci
+  repoSource' =
     name: attr:
     import ./lib/repoSource.nix {
       inherit
@@ -42,5 +58,5 @@ let
 in
 {
   repos = (lib.mapAttrs createRepo manifest) // repoOverrides;
-  repo-sources = lib.mapAttrs repoSource manifest;
+  repo-sources = lib.mapAttrs repoSource' manifest;
 }

--- a/lib/repoSource.nix
+++ b/lib/repoSource.nix
@@ -47,6 +47,14 @@ else if (lib.hasPrefix "https://gitlab.com" attr.url || type == "gitlab") && !su
 else
   fetchgit {
     inherit (attr) url;
-    inherit (revision) rev sha256;
-    fetchSubmodules = submodules;
+    inherit (revision) rev;
   }
+  // (
+    if fetchgit == builtins.fetchGit or null then
+      { inherit submodules; }
+    else
+      {
+        inherit (revision) sha256;
+        fetchSubmodules = submodules;
+      }
+  )


### PR DESCRIPTION
This PR re-applies the changes from #907, which were reverted in #917 due to #916. The issue has now been fixed by using Nixpkgs fetchers in `repo-sources`.
@Rhys-T @Pandapip1