### PR TITLE
remove dependence on treefmt-nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,28 +39,7 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
-        "treefmt-nix": "treefmt-nix"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1733222881,
-        "narHash": "sha256-JIPcz1PrpXUCbaccEnrcUS8jjEb/1vJbZz5KkobyFdM=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "49717b5af6f80172275d47a418c9719a31a78b53",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -7,10 +7,6 @@
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
-    treefmt-nix = {
-      url = "github:numtide/treefmt-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs =
@@ -45,12 +41,27 @@
       };
       imports = [
         inputs.flake-parts.flakeModules.modules
-        inputs.treefmt-nix.flakeModule
       ];
       perSystem =
         { pkgs, ... }:
         {
-          treefmt.programs.nixfmt.enable = true;
+          formatter = pkgs.treefmt.withConfig {
+            runtimeInputs = with pkgs; [
+              nixfmt-rfc-style
+            ];
+
+            settings = {
+              on-unmatched = "info";
+              tree-root-file = "flake.nix";
+
+              formatter = {
+                nixfmt = {
+                  command = "nixfmt";
+                  includes = [ "*.nix" ];
+                };
+              };
+            };
+          };
           # legacyPackages is used because nur is a package set
           # This trick with the overlay is used because it allows NUR packages to depend on other NUR packages
           legacyPackages = (pkgs.extend overlay).nur;


### PR DESCRIPTION
`pkgs.treefmt.withConfig` has the same effect as using treefmt-nix without adding another input to consumers lockfile.