### PR TITLE
feat: Add the-code-fixer-23 repository.

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1639,6 +1639,10 @@
             "submodules": true,
             "url": "https://github.com/Thaumy/nur-pkgs"
         },
+        "the-code-fixer-23-nur": {
+            "github-contact": "louiss0",
+            "url": "https://github.com/louiss0/the-code-fixer-23-nur"
+        },
         "thk": {
             "github-contact": "thkoch2001",
             "url": "https://github.com/thkoch2001/nur-packages"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [x] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

Additionally, the following points are recommended:

- [ ] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [ ] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [ ] `meta.license`, even for free packages
  - [ ] `meta.homepage`, for tracking and deduplication
  - [ ] `meta.mainProgram`, so that `nix run` works correctly


Sorry @louiss0 for the git nonsense that happened!