### PR TITLE
fix: update flake.lock

### DIFF
--- a/ci/flake.lock
+++ b/ci/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682900373,
-        "narHash": "sha256-+ckiCxbGFSs1/wHKCXAZnvb37Htf6k5nmQE3T0Y7hK8=",
+        "lastModified": 1755175540,
+        "narHash": "sha256-V0j2S1r25QnbqBLzN2Rg/dKKil789bI3P3id7bDPVc4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8b3bc690e201c8d3cbd14633dbf3462a820e73f2",
+        "rev": "a595dde4d0d31606e19dcec73db02279db59d201",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Currently, the [Update](https://github.com/nix-community/NUR/actions/runs/16983759538/job/48148706441#step:6:652) github workflow is failing because the `nix` version is 2.13.3, but the current version of Nixpkgs requires Nix >= 2.18:
```
copying path '/nix/store/wpamvpqyd3484vl1fric4cx1x92v6pxf-nix-2.13.3' from 'https://cache.nixos.org/'...

...

error:
       … while evaluating the file '/home/runner/work/_temp/nix-shell-2830-3733386514/tmpf3hm1kta/default.nix':

       … while evaluating call site

       at /home/runner/work/_temp/nix-shell-2830-3733386514/tmpf3hm1kta/default.nix:3:1:

            2|                     with import <nixpkgs> {};
            3| import /home/runner/work/NUR/NUR/lib/evalRepo.nix {
             | ^
            4|   name = "MtFBella109";

       … while calling anonymous lambda

       at /home/runner/work/NUR/NUR/lib/evalRepo.nix:1:1:

            1| {
             | ^
            2|   name,

       … while evaluating the file '/nix/store/igpm3ksd9v9ypbmwk1fg4chgxzmjqjip-source/default.nix':

       error: evaluation aborted with the following error message: '
       This version of Nixpkgs requires Nix >= 2.18, please upgrade:

       - If you are running NixOS, `nixos-rebuild' can be used to upgrade your system.

       - Alternatively, with Nix > 2.0 `nix upgrade-nix' can be used to imperatively
         upgrade Nix. You may use `nix-env --version' to check which version you have.

       - If you installed Nix using the install script (https://nixos.org/nix/install),
         it is safe to upgrade by running it again:

             curl -L https://nixos.org/nix/install | sh

       For more information, please see the NixOS release notes at
       https://nixos.org/nixos/manual or locally at
       /nix/store/igpm3ksd9v9ypbmwk1fg4chgxzmjqjip-source/nixos/doc/manual/release-notes.

       If you need further help, see https://nixos.org/nixos/support.html
       '
ERROR:nur.update:repository MtFBella109 failed to evaluate: MtFBella109 does not evaluate:
```

this pr updates the ci's flake.lock, which should also update nix. 