### PR TITLE
add workman-nur repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1836,6 +1836,10 @@
             "github-contact": "WolfangAukang",
             "url": "https://codeberg.org/wolfangaukang/nix-agordoj.git"
         },
+        "workman-nur": {
+            "github-contact": "Oliper202020",
+            "url": "https://github.com/Oliper202020/workman-nur"
+        },
         "wrvsrx": {
             "github-contact": "wrvsrx",
             "url": "https://github.com/wrvsrx/nur-packages"

--- a/repos.json.lock
+++ b/repos.json.lock
@@ -2250,6 +2250,11 @@
             "sha256": "1pqs4nszai8a6cazwlyggr2wa8xiixyx92niy1gf53q6lqcvclf3",
             "url": "https://codeberg.org/wolfangaukang/nix-agordoj.git"
         },
+        "workman-nur": {
+            "rev": "d196828849cfbfca219fcb010004497bd9c65e40",
+            "sha256": "1zi9g0fw0q34lazah42lpvymwh8ff0c0fdp0a1x960n411nafycq",
+            "url": "https://github.com/Oliper202020/workman-nur"
+        },
         "wrvsrx": {
             "rev": "75ca417955c44ec8d31b50f3929d61e9703e7804",
             "sha256": "12nfm8qsq5i2jpjdxhfdndrj74z1vaamhh9mjxshpi3r1nkzpdm8",


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [x] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

Additionally, the following points are recommended:

- [x] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [x] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [x] `meta.license`, even for free packages
  - [x] `meta.homepage`, for tracking and deduplication
  - [x] `meta.mainProgram`, so that `nix run` works correctly
