### PR TITLE
add ce-programs repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -384,6 +384,11 @@
             "github-contact": "ccicnce113424",
             "url": "https://github.com/ccicnce113424/nix-packages"
         },
+        "ce-programs": {
+            "file": "pkgs/default.nix",
+            "github-contact": "myclevorname",
+            "url": "https://github.com/myclevorname/nix-calculators"
+        },
         "chagra": {
             "github-contact": "chagra",
             "url": "https://github.com/ihebchagra/nur-packages"


### PR DESCRIPTION
(the previous PR for the repo somehow closed when rebasing)

The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [ ] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
  - `templates/hello-world` is a modification of  [an LGPL-3.0-licensed repo](https://github.com/CE-Programming/toolchain/tree/master/examples/hello_world), and `templates/bare-bones/.gitignore` is a modification of that same repo. Other than that, all applicable content is licensed under the MIT license.
- [x] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

Additionally, the following points are recommended:

- [ ] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [ ] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [ ] `meta.license`, even for free packages
  - [ ] `meta.homepage`, for tracking and deduplication
  - [ ] `meta.mainProgram`, so that `nix run` works correctly
