### PR TITLE
qchem: remove repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1471,11 +1471,6 @@
             "github-contact": "Ptival",
             "url": "https://github.com/Ptival/nur-packages"
         },
-        "qchem": {
-            "file": "nur.nix",
-            "github-contact": "markuskowa",
-            "url": "https://github.com/markuskowa/NixOS-QChem"
-        },
         "qenya": {
             "github-contact": "qenya",
             "url": "https://github.com/qenya/nur-packages"


### PR DESCRIPTION
qchem has not been not been updated since 2021.
The model how we currently package the qchem does
not fit well with NUR.

The better way to use the qchem overlay is to to use it directly via flakes.

cc @sheepforce

The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [ ] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [ ] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

Additionally, the following points are recommended:

- [ ] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [ ] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [ ] `meta.license`, even for free packages
  - [ ] `meta.homepage`, for tracking and deduplication
  - [ ] `meta.mainProgram`, so that `nix run` works correctly
