### PR TITLE
remove nolith repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1317,10 +1317,6 @@
             "github-contact": "sencrash",
             "url": "https://github.com/nodezeroat/nur-packages"
         },
-        "nolith": {
-            "github-contact": "nolith",
-            "url": "https://github.com/nolith/nur-packages"
-        },
         "noneucat": {
             "github-contact": "noneucat",
             "url": "https://git.sr.ht/~noneucat/nur-packages"


### PR DESCRIPTION
I ended up not using my NUR mirror so I'm removing it in order to delete my repository.

The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- ~~By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license~~
- ~~I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages~~

Additionally, the following points are recommended:

- [ ] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [ ] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [ ] `meta.license`, even for free packages
  - [ ] `meta.homepage`, for tracking and deduplication
  - [ ] `meta.mainProgram`, so that `nix run` works correctly
