### PR TITLE
Revert "add aciceri repository"

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -184,11 +184,6 @@
             "github-contact": "Weathercold",
             "url": "https://github.com/Weathercold/nixfiles"
         },
-        "aciceri": {
-            "file": "packages/_nur.nix",
-            "github-contact": "aciceri",
-            "url": "https://github.com/aciceri/universe"
-        },
         "afreakk": {
             "github-contact": "afreakk",
             "url": "https://github.com/afreakk/mynixrepo"


### PR DESCRIPTION
Reverts nix-community/NUR#982

Might address https://github.com/nix-community/nur-combined/issues/41. If it doesn't, then this repository wasn't the issue and can be re-added. If it does, I'll look some more into it. Regardless, I think https://github.com/git-lfs/git-lfs/issues/5815 is related.