### PR TITLE
add adam0 repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -184,6 +184,10 @@
             "github-contact": "Weathercold",
             "url": "https://github.com/Weathercold/nixfiles"
         },
+        "adam0": {
+            "github-contact": "adam01110",
+            "url": "https://github.com/adam01110/nur"
+        },
         "afreakk": {
             "github-contact": "afreakk",
             "url": "https://github.com/afreakk/mynixrepo"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [x] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

Additionally, the following points are recommended:

- [x] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [x] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [x] `meta.license`, even for free packages
  - [x] `meta.homepage`, for tracking and deduplication
  - [x] `meta.mainProgram`, so that `nix run` works correctly
