### PR TITLE
add aciceri repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -184,6 +184,11 @@
             "github-contact": "Weathercold",
             "url": "https://github.com/Weathercold/nixfiles"
         },
+        "aciceri": {
+            "file": "_nur.nix",
+            "github-contact": "aciceri",
+            "url": "https://github.com/aciceri/nur"
+        },
         "afreakk": {
             "github-contact": "afreakk",
             "url": "https://github.com/afreakk/mynixrepo"


### PR DESCRIPTION
This is my second attempt, see https://github.com/nix-community/nur-combined/issues/41

I ended up by creating a script that mirrors just a directory of my main repository to a new one that I put here.

---

The following points apply when adding a new repository to repos.json

- [X] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [X] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [X] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

Additionally, the following points are recommended:

- [X] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [X] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [X] `meta.license`, even for free packages
  - [X] `meta.homepage`, for tracking and deduplication
  - [X] `meta.mainProgram`, so that `nix run` works correctly