### PR TITLE
Revert "add iedame repository"

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -866,10 +866,6 @@
             "github-contact": "ianmurphy1",
             "url": "https://github.com/ianmurphy1/nurpkgs"
         },
-        "iedame": {
-            "github-contact": "iedame",
-            "url": "https://github.com/iedame/nur-packages"
-        },
         "ifd3f": {
             "github-contact": "ifd3f",
             "url": "https://github.com/ifd3f/nur-packages"


### PR DESCRIPTION
Reverts nix-community/NUR#1006. Currently fails to evaluate, likely the cause of https://github.com/nix-community/NUR/issues/1016.