### PR TITLE
Add cluyverth repository to index

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -8,10 +8,6 @@
             "github-contact": "0x4A6F",
             "url": "https://github.com/0x4A6F/nur-packages"
         },
-        "1235467": {
-            "github-contact": "1235467",
-            "url": "https://github.com/1235467/nurpkgs"
-        },
         "12Boti": {
             "github-contact": "12Boti",
             "url": "https://github.com/12Boti/nur"
@@ -29,26 +25,13 @@
             "type": "gitlab",
             "url": "https://git.catgirl.cloud/999eagle/nur-packages"
         },
-        "9glenda": {
-            "github-contact": "9glenda",
-            "url": "https://github.com/9glenda/nur-packages"
-        },
         "Adamekka": {
             "github-contact": "Adamekka",
             "url": "https://github.com/Adamekka/nur-packages"
         },
-        "AndrewKvalheim": {
-            "file": "nur.nix",
-            "github-contact": "AndrewKvalheim",
-            "url": "https://codeberg.org/AndrewKvalheim/configuration"
-        },
         "AsterisMono": {
             "github-contact": "AsterisMono",
             "url": "https://github.com/AsterisMono/nur-packages"
-        },
-        "AstroOrbis": {
-            "github-contact": "AstroOrbis",
-            "url": "https://github.com/AstroOrbis/nur"
         },
         "AusCyber": {
             "github-contact": "AusCyber",
@@ -111,10 +94,6 @@
             "github-contact": "MiyakoMeow",
             "url": "https://github.com/MiyakoMeow/nur-packages"
         },
-        "MtFBella109": {
-            "github-contact": "MtFBella109",
-            "url": "https://github.com/MtFBella109/nur-packages"
-        },
         "Nick1296": {
             "github-contact": "Nick1296",
             "url": "https://github.com/Nick1296/nur-packages"
@@ -148,10 +127,6 @@
             "github-contact": "Rhys-T",
             "url": "https://github.com/Rhys-T/nur-packages"
         },
-        "RossSmyth": {
-            "github-contact": "RossSmyth",
-            "url": "https://github.com/RossSmyth/nur"
-        },
         "Samuel-Martineau": {
             "github-contact": "Samuel-Martineau",
             "url": "https://github.com/Samuel-Martineau/nur-packages"
@@ -184,10 +159,6 @@
             "github-contact": "aaqaishtyaq",
             "url": "https://github.com/aaqaishtyaq/nur-packages"
         },
-        "aasg": {
-            "github-contact": "AluisioASG",
-            "url": "https://git.sr.ht/~aasg/nixexprs"
-        },
         "abszero": {
             "file": "nur.nix",
             "github-contact": "Weathercold",
@@ -202,10 +173,6 @@
             "github-contact": "adam01110",
             "url": "https://github.com/adam01110/nur"
         },
-        "afreakk": {
-            "github-contact": "afreakk",
-            "url": "https://github.com/afreakk/mynixrepo"
-        },
         "agaia": {
             "github-contact": "adam-gaia",
             "url": "https://github.com/adam-gaia/nur-packages"
@@ -217,10 +184,6 @@
         "akinokaede": {
             "github-contact": "AkinoKaede",
             "url": "https://github.com/AkinoKaede/nur-packages"
-        },
-        "alanpearce": {
-            "github-contact": "alanpearce",
-            "url": "https://git.alanpearce.eu/nix-packages"
         },
         "alarsyo": {
             "file": "pkgs/default.nix",
@@ -268,11 +231,6 @@
             "github-contact": "CutestNekoAqua",
             "url": "https://github.com/CutestNekoAqua/nur-repo"
         },
-        "arc": {
-            "file": "nur.nix",
-            "github-contact": "arcnmx",
-            "url": "https://github.com/arcnmx/nixexprs"
-        },
         "armaria": {
             "github-contact": "JonathanHope",
             "url": "https://github.com/JonathanHope/nur-armaria"
@@ -285,11 +243,6 @@
         "artturin": {
             "github-contact": "artturin",
             "url": "https://github.com/Artturin/artturin-nur"
-        },
-        "aster-void": {
-            "file": "nur.nix",
-            "github-contact": "aster-void",
-            "url": "https://github.com/aster-void/nix-repository"
         },
         "ataraxiasjel": {
             "file": "pkgs/default.nix",
@@ -320,14 +273,6 @@
             "github-contact": "balsoft",
             "url": "https://github.com/balsoft/nur-packages"
         },
-        "bandithedoge": {
-            "github-contact": "bandithedoge",
-            "url": "https://github.com/bandithedoge/nur-packages"
-        },
-        "bb010g": {
-            "github-contact": "bb010g",
-            "url": "https://github.com/bb010g/nur-packages"
-        },
         "bbjubjub": {
             "github-contact": "bbjubjub2494",
             "url": "https://github.com/bbjubjub2494/nur-expressions"
@@ -335,10 +280,6 @@
         "bd-g": {
             "github-contact": "bd-g",
             "url": "https://github.com/bd-g/nur-packages"
-        },
-        "beam": {
-            "github-contact": "jechol",
-            "url": "https://github.com/jechol/nix-beam"
         },
         "behoof4mind": {
             "github-contact": "behoof4mind",
@@ -348,10 +289,6 @@
             "github-contact": "bendlas",
             "url": "https://github.com/bendlas/nur-packages"
         },
-        "berbiche": {
-            "github-contact": "berbiche",
-            "url": "https://github.com/berbiche/nur-packages"
-        },
         "berryp": {
             "github-contact": "berryp",
             "url": "https://github.com/berryp/nur-packages"
@@ -359,10 +296,6 @@
         "bhasherbel": {
             "github-contact": "BhasherBEL",
             "url": "https://github.com/bhasherbel/nur-packages"
-        },
-        "bhipple": {
-            "github-contact": "bhipple",
-            "url": "https://github.com/bhipple/nur-packages"
         },
         "binarycat": {
             "github-contact": "lolbinarycat",
@@ -381,22 +314,9 @@
             "github-contact": "bot-wxt1221",
             "url": "https://github.com/Bot-wxt1221/Bot-wxt1221-nur"
         },
-        "breakingtv": {
-            "github-contact": "breakingtv",
-            "url": "https://github.com/BreakingTV/nur-packages"
-        },
         "brpaz": {
             "github-contact": "brpaz",
             "url": "https://github.com/brpaz/nur-packages"
-        },
-        "c0deaddict": {
-            "github-contact": "c0deaddict",
-            "url": "https://github.com/c0deaddict/nur-packages"
-        },
-        "c2vi": {
-            "file": "nur.nix",
-            "github-contact": "c2vi",
-            "url": "https://github.com/c2vi/nixos"
         },
         "caarlos0": {
             "github-contact": "caarlos0",
@@ -431,10 +351,6 @@
             "github-contact": "cu1ch3n",
             "url": "https://github.com/cu1ch3n/nur-packages"
         },
-        "cherrypiejam": {
-            "github-contact": "cherrypiejam",
-            "url": "https://github.com/cherrypiejam/nur-packages"
-        },
         "chigyutendies": {
             "github-contact": "pillowtrucker",
             "url": "https://github.com/pillowtrucker/tooo000oooot"
@@ -463,10 +379,6 @@
             "github-contact": "CinQwQeggs01",
             "url": "https://github.com/CinQwQeggs01/nur-packages-template"
         },
-        "clefru": {
-            "github-contact": "clefru",
-            "url": "https://github.com/clefru/nur-packages"
-        },
         "cluyverth": {
             "github-contact": "cluyverth",
             "url": "https://github.com/cluyverth/nur-packages"
@@ -493,19 +405,10 @@
             "github-contact": "congee",
             "url": "https://github.com/congee/nur"
         },
-        "cransom": {
-            "github-contact": "cransom",
-            "url": "https://github.com/cransom/nur-packages"
-        },
         "crazazy": {
             "file": "pkgs/default.nix",
             "github-contact": "crazazy",
             "url": "https://github.com/crazazy/nixos-config"
-        },
-        "crazedprogrammer": {
-            "file": "pkgs/nur-packages.nix",
-            "github-contact": "crazedprogrammer",
-            "url": "https://github.com/CrazedProgrammer/nix"
         },
         "crtified": {
             "github-contact": "CRTified",
@@ -536,10 +439,6 @@
             "github-contact": "dali99",
             "url": "https://git.dodsorf.as/Dandellion/NUR"
         },
-        "darkkirb": {
-            "github-contact": "DarkKirb",
-            "url": "https://git.chir.rs/darkkirb/nix-packages"
-        },
         "dawidsowa": {
             "github-contact": "dawidsowa",
             "url": "https://github.com/dawidsowa/nur-packages"
@@ -551,10 +450,6 @@
         "deeunderscore": {
             "github-contact": "DeeUnderscore",
             "url": "https://github.com/DeeUnderscore/nur-packages"
-        },
-        "definfo": {
-            "github-contact": "definfo",
-            "url": "https://github.com/definfo/nur-packages"
         },
         "demivan": {
             "github-contact": "demivan",
@@ -600,10 +495,6 @@
             "github-contact": "doomhammer",
             "url": "https://github.com/doomhammer/nur-packages"
         },
-        "draftea": {
-            "github-contact": "dateay",
-            "url": "https://github.com/Drafteame/nur-packages"
-        },
         "drewrisinger": {
             "github-contact": "drewrisinger",
             "url": "https://github.com/drewrisinger/nur-packages"
@@ -623,19 +514,6 @@
         "dtomvan": {
             "github-contact": "dtomvan",
             "url": "https://github.com/dtomvan/nur-packages"
-        },
-        "dtz": {
-            "github-contact": "dtz",
-            "url": "https://github.com/dtzWill/nur-packages"
-        },
-        "dukzcry": {
-            "github-contact": "dukzcry",
-            "type": "gitlab",
-            "url": "https://gitlab.com/repos-holder/nur-packages"
-        },
-        "dur": {
-            "github-contact": "paladhammika",
-            "url": "https://github.com/paladhammika/dur"
         },
         "dustinblackman": {
             "github-contact": "dustinblackman",
@@ -671,14 +549,6 @@
             "github-contact": "Endle",
             "url": "https://github.com/Endle/nur-packages"
         },
-        "eownerdead": {
-            "github-contact": "eownerdead",
-            "url": "https://codeberg.org/eownerdead/flakes"
-        },
-        "ethancedwards8": {
-            "github-contact": "ethancedwards8",
-            "url": "https://github.com/ethancedwards8/ethancedwards8-nur"
-        },
         "etu": {
             "github-contact": "etu",
             "url": "https://github.com/etu/nur-packages"
@@ -694,10 +564,6 @@
         "fanbb2333": {
             "github-contact": "FanBB2333",
             "url": "https://github.com/FanBB2333/nur-packages"
-        },
-        "federicoschonborn": {
-            "github-contact": "FedericoSchonborn",
-            "url": "https://codeberg.org/FedericoSchonborn/nur-packages"
         },
         "fedx": {
             "github-contact": "fedx-sudo",
@@ -739,10 +605,6 @@
             "github-contact": "fortuneteller2k",
             "url": "https://github.com/fortuneteller2k/nur"
         },
-        "frankoslaw": {
-            "github-contact": "Frankoslaw",
-            "url": "https://github.com/Frankoslaw/nur-packages"
-        },
         "friedow": {
             "github-contact": "friedow",
             "url": "https://github.com/friedow/nur-packages"
@@ -763,10 +625,6 @@
             "github-contact": "fym998",
             "url": "https://github.com/fym998/nur-packages"
         },
-        "gabr1sr": {
-            "github-contact": "gabr1sr",
-            "url": "https://github.com/gabr1sr/nur-packages"
-        },
         "gbytedev": {
             "github-contact": "gbytedev",
             "url": "https://github.com/gbytedev/nur-packages"
@@ -774,10 +632,6 @@
         "genesis": {
             "github-contact": "bignaux",
             "url": "https://github.com/bignaux/nur-packages"
-        },
-        "geonix": {
-            "github-contact": "imincik",
-            "url": "https://github.com/imincik/geonix"
         },
         "gepbird": {
             "github-contact": "gepbird",
@@ -874,17 +728,9 @@
             "github-contact": "ianmurphy1",
             "url": "https://github.com/ianmurphy1/nurpkgs"
         },
-        "ifd3f": {
-            "github-contact": "ifd3f",
-            "url": "https://github.com/ifd3f/nur-packages"
-        },
         "ihaveamac": {
             "github-contact": "ihaveamac",
             "url": "https://github.com/ihaveamac/nur-packages"
-        },
-        "ijohanne": {
-            "github-contact": "ijohanne",
-            "url": "https://github.com/ijohanne/nur-packages"
         },
         "ilya-fedin": {
             "github-contact": "ilya-fedin",
@@ -913,10 +759,6 @@
         "iuricarras": {
             "github-contact": "iuricarras",
             "url": "https://github.com/iuricarras/nur-packages"
-        },
-        "ivar": {
-            "github-contact": "IvarWithoutBones",
-            "url": "https://github.com/IvarWithoutBones/NUR"
         },
         "ixhbinphoenix": {
             "github-contact": "ixhbinphoenix",
@@ -958,17 +800,9 @@
             "github-contact": "jdev082",
             "url": "https://github.com/jdev082/jdpkgs"
         },
-        "jeffguorg": {
-            "github-contact": "jeffguorg",
-            "url": "https://github.com/jeffguorg/nur-packages"
-        },
         "jerrita": {
             "github-contact": "jerrita",
             "url": "https://github.com/jerrita/nur"
-        },
-        "jitterbug": {
-            "github-contact": "JuniorIsAJitterbug",
-            "url": "https://github.com/JuniorIsAJitterbug/nur-packages"
         },
         "jj": {
             "github-contact": "htngr",
@@ -988,25 +822,9 @@
             "github-contact": "jo1gi",
             "url": "https://github.com/jo1gi/nur-packages"
         },
-        "johnazoidberg": {
-            "github-contact": "JohnAZoidberg",
-            "url": "https://github.com/JohnAZoidberg/nur-packages"
-        },
-        "jomik": {
-            "github-contact": "Jomik",
-            "url": "https://gitlab.com/jomik/nur-expressions"
-        },
         "jonhermansen": {
             "github-contact": "jonhermansen",
             "url": "https://github.com/jonhermansen/nur-packages"
-        },
-        "jorsn": {
-            "github-contact": "jorsn",
-            "url": "https://github.com/jorsn/nur-packages"
-        },
-        "josh": {
-            "github-contact": "josh",
-            "url": "https://github.com/josh/nurpkgs"
         },
         "jpts": {
             "github-contact": "jpts",
@@ -1074,11 +892,6 @@
             "submodules": true,
             "url": "https://github.com/krebs/nur-packages"
         },
-        "kreisys": {
-            "github-contact": "kreisys",
-            "submodules": true,
-            "url": "https://github.com/kreisys/nur-packages"
-        },
         "kuflierl": {
             "github-contact": "kuflierl",
             "url": "https://github.com/kuflierl/NUR"
@@ -1129,11 +942,6 @@
             "github-contact": "lschuermann",
             "url": "https://github.com/lschuermann/nur-packages"
         },
-        "lucasew": {
-            "file": "nur.nix",
-            "github-contact": "lucasew",
-            "url": "https://github.com/lucasew/nixcfg"
-        },
         "lucasfa": {
             "github-contact": "lucasfa",
             "url": "https://github.com/lucasfa/nur-packages"
@@ -1150,15 +958,6 @@
             "github-contact": "lxl66566",
             "url": "https://github.com/lxl66566/NUR"
         },
-        "lykos153": {
-            "github-contact": "Lykos153",
-            "url": "https://github.com/Lykos153/nur-packages"
-        },
-        "m15a": {
-            "github-contact": "m15a",
-            "submodules": true,
-            "url": "https://github.com/m15a/nur-packages"
-        },
         "magnap": {
             "github-contact": "Magnap",
             "url": "https://github.com/Magnap/nur-packages"
@@ -1166,11 +965,6 @@
         "make-42": {
             "github-contact": "make-42",
             "url": "https://github.com/make-42/NUR"
-        },
-        "makefu": {
-            "file": "nur.nix",
-            "github-contact": "makefu",
-            "url": "https://github.com/makefu/nur-packages"
         },
         "marsupialgutz": {
             "github-contact": "marsupialgutz",
@@ -1180,10 +974,6 @@
             "github-contact": "Marven11",
             "url": "https://github.com/Marven11/nur-packages"
         },
-        "marzipankaiser": {
-            "github-contact": "marzipankaiser",
-            "url": "https://github.com/marzipankaiser/nur-packages"
-        },
         "materus": {
             "github-contact": "materusPL",
             "url": "https://github.com/materusPL/Nixerus"
@@ -1191,10 +981,6 @@
         "matthewbauer": {
             "github-contact": "matthewbauer",
             "url": "https://github.com/matthewbauer/nur-packages"
-        },
-        "mcaju": {
-            "github-contact": "CajuM",
-            "url": "https://github.com/CajuM/nur-packages"
         },
         "meain": {
             "github-contact": "meain",
@@ -1236,11 +1022,6 @@
             "github-contact": "Mikilio",
             "url": "https://github.com/Mikilio/nur-packages"
         },
-        "milahu": {
-            "github-contact": "milahu",
-            "submodules": true,
-            "url": "https://github.com/milahu/nur-packages"
-        },
         "minegameYTB": {
             "github-contact": "minegameYTB",
             "url": "https://github.com/minegameYTB/nurpkgs-repo"
@@ -1253,11 +1034,6 @@
             "github-contact": "mio-19",
             "url": "https://github.com/mio-19/nurpkgs"
         },
-        "misterio": {
-            "github-contact": "misterio77",
-            "type": "sourcehut",
-            "url": "https://git.sr.ht/~misterio/nix-config"
-        },
         "misuzu": {
             "github-contact": "misuzu",
             "url": "https://github.com/misuzu/mur"
@@ -1265,10 +1041,6 @@
         "mloeper": {
             "github-contact": "MartinLoeper",
             "url": "https://github.com/MartinLoeper/nur"
-        },
-        "mmilata": {
-            "github-contact": "mmilata",
-            "url": "https://github.com/mmilata/nur-packages"
         },
         "moaxcp": {
             "github-contact": "moaxcp",
@@ -1278,10 +1050,6 @@
             "github-contact": "moosingin3space",
             "url": "https://github.com/moosingin3space/nur-packages"
         },
-        "moraxyc": {
-            "github-contact": "Moraxyc",
-            "url": "https://github.com/moraxyc/nur-packages"
-        },
         "moredhel": {
             "github-contact": "moredhel",
             "url": "https://github.com/moredhel/nur-packages"
@@ -1289,11 +1057,6 @@
         "moredread": {
             "github-contact": "moredread",
             "url": "https://github.com/Moredread/nur-packages"
-        },
-        "mozilla": {
-            "file": "package-set.nix",
-            "github-contact": "tilpner",
-            "url": "https://github.com/mozilla/nixpkgs-mozilla"
         },
         "mpickering": {
             "github-contact": "mpickering",
@@ -1315,10 +1078,6 @@
         "mrtnvgr": {
             "github-contact": "mrtnvgr",
             "url": "https://github.com/mrtnvgr/nurpkgs"
-        },
-        "mur": {
-            "github-contact": "duvetfall",
-            "url": "https://github.com/duvetfall/mur"
         },
         "mweinelt": {
             "github-contact": "mweinelt",
@@ -1436,17 +1195,9 @@
             "github-contact": "nuclear06",
             "url": "https://github.com/nuclear06/NUR"
         },
-        "nykma": {
-            "github-contact": "nykma",
-            "url": "https://github.com/nykma/nur-packages"
-        },
         "ocfox": {
             "github-contact": "ocfox",
             "url": "https://github.com/ocfox/nur-pkgs"
-        },
-        "ohheyrj": {
-            "github-contact": "ohheyrj",
-            "url": "https://github.com/ohheyrj/nur"
         },
         "oluceps": {
             "github-contact": "oluceps",
@@ -1459,10 +1210,6 @@
         "onemoresuza": {
             "github-contact": "onemoresuza",
             "url": "https://github.com/onemoresuza/nur-packages"
-        },
-        "onny": {
-            "github-contact": "onny",
-            "url": "https://git.project-insanity.org/onny/nur-packages"
         },
         "ossareh": {
             "github-contact": "ossareh",
@@ -1509,14 +1256,6 @@
             "github-contact": "piegamesde",
             "url": "https://github.com/piegamesde/nur-packages"
         },
-        "piensa": {
-            "github-contact": "piensa",
-            "url": "https://github.com/piensa/nur-packages"
-        },
-        "plabadens": {
-            "github-contact": "plabadens",
-            "url": "https://github.com/plabadens/nur-packages"
-        },
         "pn": {
             "github-contact": "pniedzwiedzinski",
             "url": "https://github.com/pniedzwiedzinski/pnpkgs"
@@ -1538,17 +1277,9 @@
             "github-contact": "mistzzt",
             "url": "https://github.com/mistzzt/program-synthesis-nur"
         },
-        "propheci": {
-            "github-contact": "akshettrj",
-            "url": "https://github.com/Propheci/NixUR"
-        },
         "ps": {
             "github-contact": "patryk-s",
             "url": "https://github.com/patryk-s/nur-packages"
-        },
-        "pschuprikov": {
-            "github-contact": "pschuprikov",
-            "url": "https://github.com/pschuprikov/nur-packages"
         },
         "psiquo": {
             "github-contact": "psiquo",
@@ -1623,17 +1354,9 @@
             "github-contact": "ruixi-rebirth",
             "url": "https://github.com/Ruixi-rebirth/nur-packages"
         },
-        "rummik": {
-            "github-contact": "rummik",
-            "url": "https://gitlab.com/rummik/nixos/nur-packages"
-        },
         "running-grass": {
             "github-contact": "running-grass",
             "url": "https://github.com/running-grass/nur-packages"
-        },
-        "rutherther": {
-            "github-contact": "Rutherther",
-            "url": "https://github.com/Rutherther/nur-pkgs"
         },
         "ryan4yin": {
             "github-contact": "ryan4yin",
@@ -1683,10 +1406,6 @@
             "github-contact": "ShadowRZ",
             "url": "https://github.com/ShadowRZ/nur-packages"
         },
-        "shamilton": {
-            "github-contact": "SCOTT-HAMILTON",
-            "url": "https://github.com/SCOTT-HAMILTON/nur-packages"
-        },
         "shelvacu": {
             "file": "nur.nix",
             "github-contact": "shelvacu",
@@ -1699,10 +1418,6 @@
         "shymega": {
             "github-contact": "shymega",
             "url": "https://github.com/shymega/nixfigs-nur"
-        },
-        "sigprof": {
-            "github-contact": "sigprof",
-            "url": "https://github.com/sigprof/nur-packages"
         },
         "sikmir": {
             "github-contact": "sikmir",
@@ -1727,10 +1442,6 @@
         "sn0wm1x": {
             "github-contact": "kwaa",
             "url": "https://github.com/sn0wm1x/ur"
-        },
-        "some-pkgs": {
-            "github-contact": "SomeoneSerge",
-            "url": "https://github.com/SomeoneSerge/pkgs"
         },
         "sondr3": {
             "github-contact": "sondr3",
@@ -1802,10 +1513,6 @@
             "github-contact": "thkoch2001",
             "url": "https://github.com/thkoch2001/nur-packages"
         },
-        "tilpner": {
-            "github-contact": "tilpner",
-            "url": "https://github.com/tilpner/nur-packages"
-        },
         "timsueberkrueb": {
             "github-contact": "timsueberkrueb",
             "url": "https://github.com/timsueberkrueb/nur-packages"
@@ -1813,10 +1520,6 @@
         "tinybeachthor": {
             "github-contact": "tinybeachthor",
             "url": "https://github.com/tinybeachthor/nur-packages"
-        },
-        "tokudan": {
-            "github-contact": "tokudan",
-            "url": "https://github.com/tokudan/nur"
         },
         "tomberek": {
             "github-contact": "tomberek",
@@ -1854,10 +1557,6 @@
             "github-contact": "TwIStOy",
             "url": "https://github.com/TwIStOy/nur-packages"
         },
-        "twogn": {
-            "github-contact": "2gn",
-            "url": "https://github.com/2gn/nur-package"
-        },
         "uleenucks": {
             "github-contact": "uleenucks",
             "url": "https://github.com/uleenucks/nurpkgs"
@@ -1878,11 +1577,6 @@
             "github-contact": "VergeDX",
             "url": "https://github.com/VergeDX/nur-packages"
         },
-        "vdemeester": {
-            "file": "pkgs/default.nix",
-            "github-contact": "vdemeester",
-            "url": "https://gitlab.com/vdemeester/home"
-        },
         "vieb-nix": {
             "github-contact": "tejing1",
             "url": "https://github.com/tejing1/vieb-nix"
@@ -1898,10 +1592,6 @@
         "vojtechstep": {
             "github-contact": "vojtechstep",
             "url": "https://github.com/VojtechStep/vspkgs"
-        },
-        "vroad": {
-            "github-contact": "vroad",
-            "url": "https://github.com/vroad/nur-packages"
         },
         "vsoch": {
             "github-contact": "vsoch",
@@ -1987,10 +1677,6 @@
             "github-contact": "XYenon",
             "url": "https://github.com/XYenon/nur-packages"
         },
-        "yellowonion": {
-            "github-contact": "yellowonion",
-            "url": "https://github.com/yellowonion/nur-bcachefs"
-        },
         "yes": {
             "github-contact": "SamLukeYes",
             "url": "https://github.com/SamLukeYes/nix-custom-packages"
@@ -2015,10 +1701,6 @@
             "github-contact": "ZerataX",
             "url": "https://github.com/ZerataX/nur-packages"
         },
-        "zerozawa": {
-            "github-contact": "lz37",
-            "url": "https://github.com/lz37/nur"
-        },
         "zimeg": {
             "github-contact": "zimeg",
             "url": "https://github.com/zimeg/nur-packages"
@@ -2030,11 +1712,6 @@
         "zsien": {
             "github-contact": "zsien",
             "url": "https://github.com/zsien/nur-packages"
-        },
-        "zzzsy": {
-            "file": "parts/nur.nix",
-            "github-contact": "zzzsyyy",
-            "url": "https://github.com/zzzsyyy/flakes"
         }
     }
 }

--- a/repos.json
+++ b/repos.json
@@ -467,6 +467,10 @@
             "github-contact": "clefru",
             "url": "https://github.com/clefru/nur-packages"
         },
+        "cluyverth": {
+            "github-contact": "cluyverth",
+            "url": "https://github.com/cluyverth/nur-packages"
+        },
         "cmdorexe": {
             "github-contact": "cmdorexe",
             "url": "https://github.com/cmdorexe/nur-packages"


### PR DESCRIPTION
Adding my personal NUR repository, `cluyverth/nur-packages`, which currently includes the package for the Helium Browser (v0.6.7.1) and will be used for other personal/community Nix derivations.

---

- [ x ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [ x ] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [ x ] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

Additionally, the following points are recommended:

- [ x ] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [ x ] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [ x ] `meta.license`, even for free packages
  - [ x ] `meta.homepage`, for tracking and deduplication
  - [ x ] `meta.mainProgram`, so that `nix run` works correctly
