### PR TITLE
fix update-nur-combined action for non-github/non-gitlab repos

### DIFF
--- a/lib/repoSource.nix
+++ b/lib/repoSource.nix
@@ -45,16 +45,18 @@ else if (lib.hasPrefix "https://gitlab.com" attr.url || type == "gitlab") && !su
     inherit (revision) sha256;
   }
 else
-  fetchgit {
-    inherit (attr) url;
-    inherit (revision) rev;
-  }
-  // (
-    if fetchgit == builtins.fetchGit or null then
-      { inherit submodules; }
-    else
-      {
-        inherit (revision) sha256;
-        fetchSubmodules = submodules;
-      }
+  fetchgit (
+    {
+      inherit (attr) url;
+      inherit (revision) rev;
+    }
+    // (
+      if fetchgit == builtins.fetchGit or null then
+        { inherit submodules; }
+      else
+        {
+          inherit (revision) sha256;
+          fetchSubmodules = submodules;
+        }
+    )
   )


### PR DESCRIPTION
these were failing with `error: hash mismatch in fixed-output derivation` messages, because `fetchgit` wasn't actually being passed any sha256.

see for example this run:
<https://github.com/nix-community/nur-combined/actions/runs/19902521411/job/57050064087#step:7:753>

fixes update for at least the following NUR repos:
- Pupyrinth (https://git.gliroid.com/Pupyrinth/nur-packages)
- alanpearce (https://git.alanpearce.eu/nix-packages)
- colinsane (https://git.uninsane.org/colin/nix-files)
- shelvacu (https://git.uninsane.org/shelvacu/nix-stuff)
- wolfangaukang (https://codeberg.org/wolfangaukang/nix-agordoj.git)

The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [ ] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [ ] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

Additionally, the following points are recommended:

- [ ] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [ ] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [ ] `meta.license`, even for free packages
  - [ ] `meta.homepage`, for tracking and deduplication
  - [ ] `meta.mainProgram`, so that `nix run` works correctly
