### PR TITLE
Add mattrobenolt repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1189,6 +1189,7 @@
             "url": "https://github.com/matthewbauer/nur-packages"
         },
         "mattrobenolt": {
+            "file": "nur.nix",
             "github-contact": "mattrobenolt",
             "url": "https://github.com/mattrobenolt/nixpkgs"
         },


### PR DESCRIPTION
Adding my personal Nix packages repository.

Repository URL: https://github.com/mattrobenolt/nixpkgs

- [x] I ran `./bin/nur format-manifest` after updating `repos.json`
- [x] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [x] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

Additionally, the following points are recommended:

- [x] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [x] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [x] `meta.license`, even for free packages
  - [x] `meta.homepage`, for tracking and deduplication
  - [x] `meta.mainProgram`, so that `nix run` works correctly