### PR TITLE
add fractuscontext repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -735,6 +735,10 @@
             "github-contact": "fortuneteller2k",
             "url": "https://github.com/fortuneteller2k/nur"
         },
+        "fractuscontext": {
+            "github-contact": "fractuscontext",
+            "url": "https://github.com/fractuscontext/nix-nur"
+        },
         "frankoslaw": {
             "github-contact": "Frankoslaw",
             "url": "https://github.com/Frankoslaw/nur-packages"
@@ -818,11 +822,6 @@
         "guoard": {
             "github-contact": "guoard",
             "url": "https://github.com/guoard/nur"
-        },
-        "harukafractus": {
-            "file": "nur-everything/default.nix",
-            "github-contact": "harukafractus",
-            "url": "https://github.com/harukafractus/nix"
         },
         "henriquekh": {
             "github-contact": "henriquekirchheck",


### PR DESCRIPTION
I changed my username so I need to update the registry (see https://github.com/nix-community/NUR/pull/658)

---
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [x] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

Additionally, the following points are recommended:

- [x] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [x] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [x] `meta.license`, even for free packages
  - [ ] `meta.homepage`, for tracking and deduplication
  - [ ] `meta.mainProgram`, so that `nix run` works correctly
