### PR TITLE
Revert "Added ZEKAR repository"

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -2031,10 +2031,6 @@
             "github-contact": "zachcoyle",
             "url": "https://github.com/zachcoyle/nur-packages"
         },
-        "zekar": {
-            "github-contact": "zekar47",
-            "url": "https://codeberg.org/zekar/nur-packages"
-        },
         "zeratax": {
             "github-contact": "ZerataX",
             "url": "https://github.com/ZerataX/nur-packages"


### PR DESCRIPTION
Reverts nix-community/NUR#1037

Fixes #1048

Appears to be causing updates to fail due to an evaluation error. _Really_ ought to have an update system that's more robust to that.