### PR TITLE
fix checking of fetchgit

### DIFF
--- a/lib/repoSource.nix
+++ b/lib/repoSource.nix
@@ -51,7 +51,7 @@ else
       inherit (revision) rev;
     }
     // (
-      if fetchgit == builtins.fetchGit or null then
+      if !builtins.isAttrs fetchgit then
         { inherit submodules; }
       else
         {


### PR DESCRIPTION
The previous method for checking whether `fetchgit` originated from builtins was ineffective, as function comparisons always return `false`. Since `pkgs.fetchgit` is a functor, we now use `builtins.isAttrs` for detection.