### PR TITLE
Add ltpie123 repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1132,6 +1132,10 @@
             "github-contact": "lschuermann",
             "url": "https://github.com/lschuermann/nur-packages"
         },
+        "ltpie123": {
+            "github-contact": "ltpie123",
+            "url": "https://github.com/ltpie123/nur-packages"
+        },
         "lucasew": {
             "file": "nur.nix",
             "github-contact": "lucasew",


### PR DESCRIPTION
Adding my NUR repository containing the lazymake package.

**Repository:** https://github.com/ltpie123/nur-packages

**Packages:**
- `lazymake` v0.2.0 - Modern TUI for Makefiles with interactive target selection and dependency visualization

**Package details:**
- Language: Go
- License: MIT
- Builds successfully: ✅
- Follows Nixpkgs conventions: ✅
- Includes flake.nix for modern Nix support: ✅

This is my first NUR submission. The package has been tested locally and builds successfully.