### PR TITLE
fix(combine): path traversal allows arbitrary directory deletion via repo name

### DIFF
--- a/ci/nur/combine.py
+++ b/ci/nur/combine.py
@@ -43,8 +43,27 @@ def commit_files(files: List[str], message: str) -> None:
         subprocess.check_call(["git", "commit", "-m", message])
 
 
+def resolve_repo_path(path: Path, name: str) -> Path:
+    name_path = Path(name)
+    if (
+        name_path.is_absolute()
+        or name in ("", ".", "..")
+        or name_path.name != name
+    ):
+        raise ValueError(f"invalid repository name: {name}")
+
+    base_path = path.resolve()
+    repo_path = base_path.joinpath(name).resolve()
+    try:
+        repo_path.relative_to(base_path)
+    except ValueError as e:
+        raise ValueError(f"invalid repository name: {name}") from e
+
+    return repo_path
+
+
 def commit_repo(repo: Repo, message: str, path: Path) -> Repo:
-    repo_path = path.joinpath(repo.name).resolve()
+    repo_path = resolve_repo_path(path, repo.name)
 
     tmp: Optional[TemporaryDirectory] = TemporaryDirectory(prefix=str(repo_path.parent))
     assert tmp is not None
@@ -102,7 +121,12 @@ def update_combined_repo(
 
 
 def remove_repo(repo: Repo, path: Path) -> None:
-    repo_path = path.joinpath("repos", repo.name).resolve()
+    try:
+        repo_path = resolve_repo_path(path.joinpath("repos"), repo.name)
+    except ValueError:
+        logger.warning(f"Skipping removal for invalid repository name: {repo.name}")
+        return
+
     if repo_path.exists():
         shutil.rmtree(repo_path)
     with chdir(path):

--- a/ci/nur/eval.py
+++ b/ci/nur/eval.py
@@ -14,6 +14,13 @@ logger = logging.getLogger(__name__)
 
 
 async def eval_repo(repo: Repo, repo_path: Path) -> None:
+    canonicalized_repo_path = repo_path.resolve()
+    source_path = canonicalized_repo_path.joinpath(repo.file).resolve()
+    try:
+        source_path.relative_to(canonicalized_repo_path)
+    except ValueError as e:
+        raise EvalError(f"{repo.name} has invalid file path: {repo.file}") from e
+
     with tempfile.TemporaryDirectory() as d:
         eval_path = Path(d).joinpath("default.nix")
         with open(eval_path, "w") as f:
@@ -23,7 +30,7 @@ async def eval_repo(repo: Repo, repo_path: Path) -> None:
 import {EVALREPO_PATH} {{
   name = "{repo.name}";
   url = "{repo.url}";
-  src = {repo_path.joinpath(repo.file)};
+  src = {source_path};
   inherit pkgs lib;
 }}
 """

--- a/ci/nur/manifest.py
+++ b/ci/nur/manifest.py
@@ -60,12 +60,23 @@ class Repo:
         branch: Optional[str],
         locked_version: Optional[LockedVersion],
     ) -> None:
+        name_path = Path(name)
+        if (
+            name_path.is_absolute()
+            or name in ("", ".", "..")
+            or name_path.name != name
+        ):
+            raise ValueError(f"invalid repository name: {name}")
+
         self.name = name
         self.url = url
         self.submodules = submodules
         if file_ is None:
             self.file = "default.nix"
         else:
+            file_path = Path(file_)
+            if file_path.is_absolute() or ".." in file_path.parts:
+                raise ValueError(f"invalid repository file path: {file_}")
             self.file = file_
         self.branch = branch
         self.locked_version = None


### PR DESCRIPTION
## 🔒 Security Fix

### Problem
`commit_repo()` builds `repo_path` from `path.joinpath(repo.name).resolve()` and then calls `shutil.rmtree(repo_path)` if it exists. If `repo.name` contains traversal segments (e.g. `../../...`), the resolved path can escape the intended repository directory. In CI/automation, a crafted manifest entry could delete or overwrite arbitrary directories on the runner.

**Severity**: `critical`
**File**: `ci/nur/combine.py`

### Solution
Validate and constrain `repo.name` before filesystem use, and enforce that the resolved path stays under the base directory.



### Changes
- `ci/nur/combine.py` (modified)
- `ci/nur/eval.py` (modified)
- `ci/nur/manifest.py` (modified)

The following points apply when adding a new repository to repos.json

- [ ] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [ ] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [ ] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

Additionally, the following points are recommended:

- [ ] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [ ] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [ ] `meta.license`, even for free packages
  - [ ] `meta.homepage`, for tracking and deduplication
  - [ ] `meta.mainProgram`, so that `nix run` works correctly

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #1102