### PR TITLE
nur: add ie-r (miaupaw)

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1289,13 +1289,13 @@
             "github-contact": "mgord9518",
             "url": "https://github.com/mgord9518/nur"
         },
-        "miaupaw": {
-            "github-contact": "miaupaw",
-            "url": "https://github.com/miaupaw/ie-r"
-        },
         "mhuesch": {
             "github-contact": "mhuesch",
             "url": "https://github.com/mhuesch/nur-packages"
+        },
+        "miaupaw": {
+            "github-contact": "miaupaw",
+            "url": "https://github.com/miaupaw/ie-r"
         },
         "mic92": {
             "github-contact": "Mic92",

--- a/repos.json
+++ b/repos.json
@@ -1289,6 +1289,10 @@
             "github-contact": "mgord9518",
             "url": "https://github.com/mgord9518/nur"
         },
+        "miaupaw": {
+            "github-contact": "miaupaw",
+            "url": "https://github.com/miaupaw/ie-r"
+        },
         "mhuesch": {
             "github-contact": "mhuesch",
             "url": "https://github.com/mhuesch/nur-packages"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [ ] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [x] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages
- [x] "Package uses a custom unfree license (free for individuals and small organizations, commercial use
  requires paid license)." 

Additionally, the following points are recommended:

- [ ] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [x] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [x] `meta.license`, even for free packages
  - [x] `meta.homepage`, for tracking and deduplication
  - [x] `meta.mainProgram`, so that `nix run` works correctly
