### PR TITLE
feat: add whizbangdevelopers-org NUR repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -2093,6 +2093,10 @@
             "github-contact": "wenjinnn",
             "url": "https://github.com/wenjinnn/nur-packages"
         },
+        "whizbangdevelopers-org": {
+            "github-contact": "wriver4",
+            "url": "https://github.com/whizbangdevelopers-org/nur-packages"
+        },
         "whs": {
             "github-contact": "whs",
             "url": "https://github.com/whs/nix"


### PR DESCRIPTION
Registers `whizbangdevelopers-org` as a NUR namespace.

**Repo:** https://github.com/whizbangdevelopers-org/nur-packages  
**Contact:** @wriver4

**Packages:**

| Package | License | Description |
|---|---|---|
| `weaver-free` | AGPL-3.0 | NixOS workload isolation — unified container + MicroVM management |

The repository CI builds against nixpkgs-unstable, nixos-unstable, and nixos-25.11.