### PR TITLE
add connoromalley repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -534,6 +534,10 @@
             "github-contact": "congee",
             "url": "https://github.com/congee/nur"
         },
+        "connoromalley": {
+            "github-contact": "connordennyomalley",
+            "url": "https://codeberg.org/connoromalley/nur-packages"
+        },
         "cransom": {
             "github-contact": "cransom",
             "url": "https://github.com/cransom/nur-packages"


### PR DESCRIPTION
My [repository](https://codeberg.org/connoromalley/nur-packages) contains the `ginac` package. This package is already in `nixpkgs`; however, it doesn't work on darwin, and my pr to fix this is taking a very long time to be reviewed (and for CI to run). I have a friend who wants to use the package, and so I'm hoping to make my fixed version easily accessible through NUR in the meantime.

I have derivations that are not in `nixpkgs` that I plan to make available through my repository, but they are currently quite hacky derivations, and I want to polish them a bit more before making them available. 

Thanks in advance for the review.

**Checklist**:
- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [x] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

Additionally, the following points are recommended:

- [x] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [x] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [x] `meta.license`, even for free packages
  - [x] `meta.homepage`, for tracking and deduplication
  - [x] `meta.mainProgram`, so that `nix run` works correctly
