### PR TITLE
add ahmet-cetinkaya repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -234,6 +234,11 @@
             "github-contact": "ahi6",
             "url": "https://github.com/ahi6/nurpkgs"
         },
+        "ahmet-cetinkaya": {
+            "file": "nixos/pkgs/nur.nix",
+            "github-contact": "ahmet-cetinkaya",
+            "url": "https://github.com/ahmet-cetinkaya/dotfiles"
+        },
         "akinokaede": {
             "github-contact": "AkinoKaede",
             "url": "https://github.com/AkinoKaede/nur-packages"


### PR DESCRIPTION
## NUR Repository Entry

### Checklist (Required)

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [x] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

### Checklist (Recommended)

- [x] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information.
  - [x] `meta.description`
  - [x] `meta.license`
  - [x] `meta.homepage`
  - [x] `meta.mainProgram`

### Repository Details

- **URL**: https://github.com/ahmet-cetinkaya/dotfiles
- **NUR File**: `nixos/pkgs/nur.nix`

### Packages Available

- `antigravity-tools-bin` — Professional Antigravity Account Manager & Switcher (`meta.license = cc-by-nc-sa-40`, `meta.sourceProvenance = binaryNativeCode`)
- `zed-preview-bin` — A high-performance, multiplayer code editor (preview binary) (`meta.license = gpl3Plus/agpl3Plus/asl20`, `meta.sourceProvenance = binaryNativeCode`)

### Verification

Both packages evaluate successfully.

- `nix-env -f . -qa antigravity-tools-bin --meta` — OK
- `nix-env -f . -qa zed-preview-bin --meta` — OK