### PR TITLE
Add rapatao repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1730,6 +1730,9 @@
             "github-contact": "raizyr",
             "url": "https://github.com/raizyr/nur-packages"
         },
+        "rapatao": {
+            "url": "https://github.com/rapatao/nur-packages"
+        },
         "rconan": {
             "github-contact": "riconnon",
             "url": "https://gitlab.com/rconan/nix-packages"

--- a/repos.json
+++ b/repos.json
@@ -1731,6 +1731,7 @@
             "url": "https://github.com/raizyr/nur-packages"
         },
         "rapatao": {
+            "github-contact": "rapatao",
             "url": "https://github.com/rapatao/nur-packages"
         },
         "rconan": {


### PR DESCRIPTION
Adds my NUR repo https://github.com/rapatao/nur-packages, which packages `md2` (Markdown -> PDF/HTML/text CLI). Builds and runs on x86_64-linux; pure Go, no platform restriction.