### PR TITLE
add infgotoinf repository + run `black ci/nur`

### DIFF
--- a/ci/nur/eval.py
+++ b/ci/nur/eval.py
@@ -17,8 +17,7 @@ async def eval_repo(repo: Repo, repo_path: Path) -> None:
     with tempfile.TemporaryDirectory() as d:
         eval_path = Path(d).joinpath("default.nix")
         with open(eval_path, "w") as f:
-            f.write(
-                f"""
+            f.write(f"""
                     with import <nixpkgs> {{}};
 import {EVALREPO_PATH} {{
   name = "{repo.name}";
@@ -26,8 +25,7 @@ import {EVALREPO_PATH} {{
   src = {repo_path.joinpath(repo.file)};
   inherit pkgs lib;
 }}
-"""
-            )
+""")
 
         canonicalized_eval_path = eval_path.resolve()
         # fmt: off

--- a/repos.json
+++ b/repos.json
@@ -997,6 +997,10 @@
             "github-contact": "immae",
             "url": "https://git.immae.eu/perso/Immae/Config/Nix/NUR.git"
         },
+        "infgotoinf": {
+            "github-contact": "infgotoinf",
+            "url": "https://github.com/infgotoinf/nur-packages"
+        },
         "inogai": {
             "github-contact": "inogai",
             "url": "https://github.com/inogai/nur-packages"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [x] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

Additionally, the following points are recommended:

- [x] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [x] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [x] `meta.license`, even for free packages
  - [x] `meta.homepage`, for tracking and deduplication
  - [ ] `meta.mainProgram`, so that `nix run` works correctly
  (no main program - it's a font)
  
  https://github.com/infgotoinf/nur-packages/
