### PR TITLE
ci: automate deleted repository removal

### DIFF
--- a/ci/nur/manifest.py
+++ b/ci/nur/manifest.py
@@ -1,4 +1,5 @@
 import json
+import shutil
 from enum import Enum, auto
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -159,3 +160,19 @@ def load_manifest(manifest_path: PathType, lock_path: PathType) -> Manifest:
         repos.append(Repo(name, url, submodules, type_, file_, branch_, locked_version))
 
     return Manifest(repos)
+
+
+def remove_repos(repos: List[Repo], manifest_path: PathType) -> None:
+    path = to_path(manifest_path)
+
+    with open(path) as f:
+        data = json.load(f)
+
+    for name in [repo.name for repo in repos]:
+        data["repos"].pop(name, None)
+
+    tmp_path = str(path) + ".tmp"
+    with open(tmp_path, "w+") as tmp:
+        json.dump(data, tmp, indent=4, sort_keys=True)
+        tmp.write("\n")
+    shutil.move(tmp_path, path)

--- a/ci/nur/prefetch.py
+++ b/ci/nur/prefetch.py
@@ -53,7 +53,7 @@ class GitPrefetcher:
 
         async with aiohttp.ClientSession() as session:
             async with session.get(info_url) as resp:
-                if resp.status == 401:
+                if resp.status in [401, 402, 403, 404, 410, 451]:
                     raise RepositoryDeletedError("Repository deleted!")
                 elif resp.status != 200:
                     raise NurError(

--- a/ci/nur/update.py
+++ b/ci/nur/update.py
@@ -3,8 +3,9 @@ import logging
 from argparse import Namespace
 from typing import List, Optional, Tuple
 
+from .error import RepositoryDeletedError
 from .eval import EvalError, eval_repo
-from .manifest import LockedVersion, Repo, load_manifest, update_lock_file
+from .manifest import LockedVersion, Repo, load_manifest, remove_repos, update_lock_file
 from .path import LOCK_PATH, MANIFEST_PATH
 from .prefetch import prefetcher_for
 
@@ -53,7 +54,12 @@ async def update_command(args: Namespace) -> None:
             results.append((i, None, e))
 
             async with log_lock:
-                if isinstance(e, EvalError) and repo.locked_version is None:
+                if isinstance(e, RepositoryDeletedError):
+                    logger.warning(
+                        f"repository {repo.name} appears to have been deleted "
+                        "upstream; removing it from the repository list"
+                    )
+                elif isinstance(e, EvalError) and repo.locked_version is None:
                     logger.error(
                         f"repository {repo.name} failed to evaluate: {e}. "
                         "This repo is not yet in our lock file!!!!"
@@ -70,10 +76,16 @@ async def update_command(args: Namespace) -> None:
     ]
     await asyncio.gather(*tasks)
 
-    updated_repos: List[Repo] = list(manifest.repos)
+    updated_repos: List[Repo] = []
+    deleted_repos: List[Repo] = []
 
-    for i, updated, err in results:
+    for i, updated, err in sorted(results, key=lambda i: i[0]):
         if err is None and updated is not None:
-            updated_repos[i] = updated
+            updated_repos.append(updated)
+        elif isinstance(err, RepositoryDeletedError):
+            deleted_repos.append(manifest.repos[i])
+        else:
+            updated_repos.append(manifest.repos[i])
 
     update_lock_file(updated_repos, LOCK_PATH)
+    remove_repos(deleted_repos, MANIFEST_PATH)


### PR DESCRIPTION
Automatically removes deleted repositories from the repository list. This should speed up CI and other tooling I'm working on by a small amount.

Has been tested locally and does indeed work.