### PR TITLE
default.nix: add per-repository tryEval; ci: skip eval step

### DIFF
--- a/ci/nur/update.py
+++ b/ci/nur/update.py
@@ -12,23 +12,34 @@ from .prefetch import prefetcher_for
 logger = logging.getLogger(__name__)
 
 
-async def update(repo: Repo) -> Repo:
+async def update(
+    repo: Repo, do_evaluate: bool = False
+) -> Tuple[Repo, Optional[EvalError]]:
     prefetcher = prefetcher_for(repo)
 
     latest_commit = await prefetcher.latest_commit()
 
     if repo.locked_version is not None and repo.locked_version.rev == latest_commit:
-        return repo
+        return repo, None
 
     sha256, repo_path = await prefetcher.prefetch(latest_commit)
-    await eval_repo(repo, repo_path)
+
+    eval_error: Optional[EvalError] = None
+    if do_evaluate:
+        try:
+            await eval_repo(repo, repo_path)
+        except EvalError as e:
+            eval_error = e
+
     repo.locked_version = LockedVersion(
         repo.url, latest_commit, sha256, repo.submodules
     )
-    return repo
+    return repo, eval_error
 
 
-async def update_command(args: Namespace) -> None:
+async def update_command(
+    args: Namespace, do_evaluate: bool = False, hold_eval_fail: bool = False
+) -> None:
     logging.basicConfig(level=logging.INFO)
 
     manifest = load_manifest(MANIFEST_PATH, LOCK_PATH)
@@ -37,19 +48,41 @@ async def update_command(args: Namespace) -> None:
 
     results: List[Tuple[int, Optional[Repo], Optional[BaseException]]] = []
 
-    async def run_one(i: int, repo: Repo) -> None:
+    async def run_one(
+        i: int, repo: Repo, do_evaluate: bool = False, hold_eval_fail: bool = False
+    ) -> None:
         try:
-            updated = await update(repo)
-
-            results.append((i, updated, None))
+            updated, eval_error = await update(repo, do_evaluate)
 
             async with log_lock:
-                if updated.locked_version is not None:
+                if eval_error is not None:
+                    if hold_eval_fail:
+                        logger.error(
+                            f"repository {repo.name} failed to evaluate: {eval_error}"
+                        )
+                        results.append((i, None, eval_error))
+                    elif updated.locked_version is None:
+                        logger.error(
+                            f"repository {repo.name} failed to evaluate: {eval_error}. "
+                            "It also failed to get a locked_version, but updating anyway."
+                        )
+                        results.append((i, updated, eval_error))
+                    else:
+                        logger.error(
+                            f"repository {repo.name} failed to evaluate: {eval_error}. "
+                            f"Locking it to {updated.locked_version.rev} anyway."
+                        )
+                        results.append((i, updated, None))
+                elif updated.locked_version is not None:
                     logger.info(
                         f"Updated repository {repo.name} -> {updated.locked_version.rev}"
                     )
+                    results.append((i, updated, None))
                 else:
-                    logger.info(f"Updated repository {repo.name}")
+                    logger.info(
+                        f"Updated repository {repo.name} but failed to get locked_version"
+                    )
+                    results.append((i, updated, None))
         except BaseException as e:
             results.append((i, None, e))
 
@@ -59,20 +92,14 @@ async def update_command(args: Namespace) -> None:
                         f"repository {repo.name} appears to have been deleted "
                         "upstream; removing it from the repository list"
                     )
-                elif isinstance(e, EvalError) and repo.locked_version is None:
-                    logger.error(
-                        f"repository {repo.name} failed to evaluate: {e}. "
-                        "This repo is not yet in our lock file!!!!"
-                    )
-                elif isinstance(e, EvalError):
-                    logger.error(f"repository {repo.name} failed to evaluate: {e}")
                 else:
                     logger.exception(
                         f"Failed to update repository {repo.name}", exc_info=e
                     )
 
     tasks = [
-        asyncio.create_task(run_one(i, repo)) for i, repo in enumerate(manifest.repos)
+        asyncio.create_task(run_one(i, repo, do_evaluate, hold_eval_fail))
+        for i, repo in enumerate(manifest.repos)
     ]
     await asyncio.gather(*tasks)
 

--- a/default.nix
+++ b/default.nix
@@ -18,6 +18,16 @@ let
 
   inherit (nurpkgs) lib;
 
+  tryEvalRepo =
+    name: fallback: value:
+    let
+      result = builtins.tryEval value;
+    in
+    if result.success then
+      result.value
+    else
+      lib.warn "NUR: repository '${name}' failed to evaluate and was skipped" fallback;
+
   repoSource =
     name: attr:
     import ./lib/repoSource.nix {
@@ -49,11 +59,13 @@ let
 
   createRepo =
     name: attr:
-    import ./lib/evalRepo.nix {
-      inherit name pkgs lib;
-      inherit (attr) url;
-      src = repoSource name attr + ("/" + (attr.file or ""));
-    };
+    tryEvalRepo name { } (
+      import ./lib/evalRepo.nix {
+        inherit name pkgs lib;
+        inherit (attr) url;
+        src = repoSource name attr + ("/" + (attr.file or ""));
+      }
+    );
 
 in
 {


### PR DESCRIPTION
Fixes https://github.com/nix-community/NUR/issues/919

Should speed up updates significantly, as well as unblocking individual repository updates if/when nix makes backwards incompatible changes