### PR TITLE
repos: a couple targeted drops

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -234,10 +234,6 @@
             "github-contact": "AkinoKaede",
             "url": "https://github.com/AkinoKaede/nur-packages"
         },
-        "alanpearce": {
-            "github-contact": "alanpearce",
-            "url": "https://git.alanpearce.eu/nix-packages"
-        },
         "alarsyo": {
             "file": "pkgs/default.nix",
             "github-contact": "alarsyo",

--- a/repos.json
+++ b/repos.json
@@ -102,11 +102,6 @@
             "github-contact": "HeyImKyu",
             "url": "https://github.com/HeyImKyu/nur-packages"
         },
-        "INFO4-19": {
-            "github-contact": "Cosciad",
-            "type": "gitlab",
-            "url": "https://gricad-gitlab.univ-grenoble-alpes.fr/Projets-INFO4/18-19/19/code"
-        },
         "LuisChDev": {
             "github-contact": "LuisChDev",
             "url": "https://github.com/LuisChDev/nur-packages"


### PR DESCRIPTION
The first (INFO4-19) seems misconfigured somehow and/or we're hitting its Anubis (it's giving us HTML instead of a commit hash), and the other (alanpearce) is broken in a way I don't understand but that holds up everything else.

CC @Cosciad @alanpearce; please fix those issues if you would like them to be re-added