### PR TITLE
add silicalet repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1840,6 +1840,10 @@
             "github-contact": "sikmir",
             "url": "https://github.com/sikmir/nur-packages"
         },
+        "silicalet": {
+            "github-contact": "silicalet",
+            "url": "https://github.com/silicalet/nur-packages-silicalet"
+        },
         "skiletro": {
             "github-contact": "skiletro",
             "url": "https://github.com/skiletro/nur-repo"


### PR DESCRIPTION
Adds the silicalet NUR repository:

- Repository: https://github.com/silicalet/nur-packages-silicalet
- Contact: @silicalet

Validation performed:

- `./bin/nur format-manifest`
- `./bin/nur eval /path/to/nur-packages-silicalet` (`OK`)

Only `repos.json` is included, as required by the contribution documentation.