### PR TITLE
Revert "Quality: Lockfile entry is discarded for matching URLs due to inverted comparison"

### DIFF
--- a/ci/nur/manifest.py
+++ b/ci/nur/manifest.py
@@ -77,7 +77,7 @@ class Repo:
 
         if (
             locked_version is not None
-            and locked_version.url == url.geturl()
+            and locked_version.url != url.geturl()
             and locked_version.submodules == submodules
         ):
             self.locked_version = locked_version


### PR DESCRIPTION
Reverts nix-community/NUR#1106

Appears to break nur-search

https://github.com/nix-community/nur-search/commit/fd9476003f9fb528d4e3a59c1455b97c2a3e11a8