### PR TITLE
fix: add legacy homeModules fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,8 @@ Home Manager modules should be placed in the `homeModules` attribute:
 
 These modules are then accessible as `nur.repos.<repo>.modules.homeManager.<module>` in flakes.
 
+The legacy `modules` attribute is also supported as a fallback for `homeModules`.
+
 #### Providing Darwin modules
 
 Darwin (nix-darwin) modules should be placed in the `darwinModules` attribute:

--- a/flake.nix
+++ b/flake.nix
@@ -160,7 +160,7 @@
               let
                 darwinModules = r.darwinModules or { };
                 flakeModules = r.flakeModules or { };
-                homeModules = r.homeModules or { };
+                homeModules = r.homeModules or r.modules or { };
                 nixosModules = r.nixosModules or r.modules or { };
               in
               {


### PR DESCRIPTION
## Summary

- mirror the existing legacy `modules` fallback for `homeModules`
- document the legacy Home Manager module compatibility behavior

Fixes #1147

## Verification

- `nix flake check --no-build` in `nixos/nix:2.31.2`
- `nix eval --json '.#repos.charmbracelet.homeModules' --apply builtins.attrNames` returns `["darwin","homeManager","nixos"]`
- `nix-instantiate --parse flake.nix`
- `git diff --check`