### PR TITLE
add iamanaws repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -885,6 +885,11 @@
             "github-contact": "iagocq",
             "url": "https://github.com/iagocq/nix"
         },
+        "iamanaws": {
+            "file": "pkgs/default.nix",
+            "github-contact": "iamanaws",
+            "url": "https://github.com/iamanaws/dotfiles"
+        },
         "ianmurphy1": {
             "github-contact": "ianmurphy1",
             "url": "https://github.com/ianmurphy1/nurpkgs"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [ ] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [x] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

_I'm pointing to subdir with the packages, does the entire repo needs to be under MIT license? It is currently under BSD 3-Clause (compatible) license. I could explicitly dual license if required, just want to know the position here._

---

Additionally, the following points are recommended:

- [x] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [x] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [x] `meta.license`, even for free packages
  - [x] `meta.homepage`, for tracking and deduplication
  - [x] `meta.mainProgram`, so that `nix run` works correctly
