### PR TITLE
repos: add crimsonvariable

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -535,6 +535,10 @@
             "github-contact": "crazedprogrammer",
             "url": "https://github.com/CrazedProgrammer/nix"
         },
+        "crimsonvariable": {
+            "github-contact": "crimsonvariable",
+            "url": "https://github.com/crimsonvariable/nur-packages"
+        },
         "crtified": {
             "github-contact": "CRTified",
             "url": "https://github.com/CRTified/nur-packages"


### PR DESCRIPTION
## What changed

Registers the `crimsonvariable` NUR repository from
[`crimsonvariable/nur-packages`](https://github.com/crimsonvariable/nur-packages).
The initial package set exposes `ff00-vwm`, an X11 per-monitor video wallpaper
manager written in Rust and GTK4.

## Why

The repository provides an installable NUR path for FF00 VWM's first public
prerelease while its feature model continues to develop before a future
nixpkgs submission.

## Validation

- `./bin/nur format-manifest`
- `./bin/nur update` resolved `crimsonvariable` to commit `7516c95`
- `./bin/nur eval /mnt/codex/Codex/projects/Public/nur-packages` returned `OK`
- `nix build --no-link .#ff00-vwm`
- `nix flake check --no-build`
- non-flake `nix-build --no-out-link -A ff00-vwm`
- all 17 upstream Rust tests passed in the Nix build
- packaged executable reports `ff00-vwm 0.1.0-alpha.1`

Some unrelated repositories reported transient DNS or upstream availability
errors during the full registry update; the new `crimsonvariable` repository
updated and evaluated successfully.
