### PR TITLE
docs: add standalone Home Manager flake configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,41 @@ in
 }
 ```
 
+### Using the flake in a standalone Home Manager configuration
+
+The section above covers Home Manager used as a NixOS (or nix-darwin) module.
+If you instead build your Home Manager configuration standalone, with
+`home-manager.lib.homeManagerConfiguration`, add the NUR overlay and any
+repo modules you need to its `modules` list directly:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nur = {
+      url = "github:nix-community/NUR";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, home-manager, nur, ... }: {
+    homeConfigurations.myUser = home-manager.lib.homeManagerConfiguration {
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      modules = [
+        # Adds the NUR overlay to Home Manager's pkgs
+        nur.modules.homeManager.default
+        # Import all Home Manager modules published by a NUR repo:
+        { imports = nixpkgs.lib.attrValues nur.repos.moredhel.modules.homeManager; }
+      ];
+    };
+  };
+}
+```
+
 ## Finding packages
 
 You can find all packages using


### PR DESCRIPTION
Closes #545
Closes #485

## What

The README's "Integrating with Home Manager" section covers Home Manager
used as a NixOS/nix-darwin module (with and without flakes), but has
nothing for a standalone `home-manager.lib.homeManagerConfiguration`
setup. Both #545 and #485 report exactly this gap, with ~2 years of
comments from different users landing on inconsistent, sometimes-stale
workarounds because there was nowhere canonical to look.

Added a new "Using the flake in a standalone Home Manager configuration"
subsection right after the existing Home Manager section, showing the NUR
overlay + repo modules added directly to `homeManagerConfiguration`'s
`modules` list.

One thing worth calling out: several of the working examples posted in
those two issue threads (including the one from a maintainer, quoted in
#485) use `nur.hmModules.nur`. I checked `flake.nix` against current
`main` before writing this, and that's not the current schema anymore —
`flake.modules.homeManager.default` / `repos.<repo>.modules.homeManager`
is what's actually exposed today (added in #1101, with #1187 adding a
legacy `homeModules` fallback for backwards compat). So this PR documents
the current attribute names rather than the older ones from those threads,
to avoid the docs going stale again immediately.

## Testing

Documentation-only. Followed the exact structure/style of the existing
"Using the flake in NixOS" and "Integrating with Home Manager" examples
right above it (same overlay-injection + module-import pattern), and
verified `flake.modules.homeManager.default` and
`repos.<repo>.modules.homeManager` both exist in current `flake.nix`
before using them.

Marking this AI-assisted: this PR was authored by an AI coding agent
(Claude).
