### PR TITLE
Replace obsolete mlos-host-utils with Moonlight OS Helios

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1393,6 +1393,11 @@
             "github-contact": "moaxcp",
             "url": "https://github.com/moaxcp/nur"
         },
+        "moonlight-os": {
+            "file": "packaging/nix/nur.nix",
+            "github-contact": "MopigamesYT",
+            "url": "https://github.com/moonlight-os/helios"
+        },
         "moosingin3space": {
             "github-contact": "moosingin3space",
             "url": "https://github.com/moosingin3space/nur-packages"

--- a/repos.json
+++ b/repos.json
@@ -1397,11 +1397,6 @@
             "github-contact": "moosingin3space",
             "url": "https://github.com/moosingin3space/nur-packages"
         },
-        "mopigames": {
-            "file": "packaging/nix/nur.nix",
-            "github-contact": "MopigamesYT",
-            "url": "https://github.com/MopigamesYT/moonlight-os"
-        },
         "moraxyc": {
             "github-contact": "Moraxyc",
             "url": "https://github.com/moraxyc/nur-packages"


### PR DESCRIPTION
## Summary

- remove the obsolete `mopigames` NUR repository for `mlos-host-utils`
- register the replacement `moonlight-os/helios` repository
- use Helios's dedicated `packaging/nix/nur.nix` entry point

## Validation

- Helios Nix package builds and runs successfully on x86_64-linux
- NixOS module evaluation and udev rules are validated in Helios CI
- clean Helios packaging workflow: https://github.com/moonlight-os/helios/actions/runs/32657725591
- Helios packaging merged in https://github.com/moonlight-os/helios/pull/4