### PR TITLE
update `0komo` entry, rename to `komo`

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1,9 +1,5 @@
 {
     "repos": {
-        "0komo": {
-            "github-contact": "0komo",
-            "url": "https://github.com/0komo/nurpkgs"
-        },
         "0x4A6F": {
             "github-contact": "0x4A6F",
             "url": "https://github.com/0x4A6F/nur-packages"
@@ -1167,6 +1163,10 @@
         "kolloch": {
             "github-contact": "kolloch",
             "url": "https://github.com/kolloch/nur-packages"
+        },
+        "komo": {
+            "github-contact": "asumbek",
+            "url": "https://git.gay/kromfin/nur-pkgs"
         },
         "kongjian520": {
             "github-contact": "KongJian520",


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [x] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

Additionally, the following points are recommended:

- [x] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [x] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [x] `meta.license`, even for free packages
  - [x] `meta.homepage`, for tracking and deduplication
  - [x] `meta.mainProgram`, so that `nix run` works correctly
