### PR TITLE
Add theluckystrike repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -2002,6 +2002,10 @@
             "github-contact": "louiss0",
             "url": "https://github.com/louiss0/the-code-fixer-23-nur"
         },
+        "theluckystrike": {
+            "github-contact": "theluckystrike",
+            "url": "https://github.com/theluckystrike/nur-packages"
+        },
         "therobot2105": {
             "github-contact": "therobot2105",
             "url": "https://github.com/therobot2105/nur-packages"


### PR DESCRIPTION
Registers https://github.com/theluckystrike/nur-packages.

The repository currently ships one package, `bln-mcp-server`: a Model Context
Protocol stdio server that exposes grammar, style, translation and tone tools to
MCP clients (Claude Desktop, Claude Code, Cursor). `check_grammar` and
`improve_writing` run fully offline against a local 70-rule engine — no API key,
no environment variables and no network access at run time.

- Built with `buildNpmPackage`; `src` and `npmDepsHash` are pinned.
- `installCheckPhase` drives the built binary over stdio and asserts all four
  tools are listed, so CI fails if the server does not actually start.
- CI green on all three template channels (nixpkgs-unstable, nixos-unstable,
  nixos-26.05): https://github.com/theluckystrike/nur-packages/actions/runs/33152994224
- The NUR update trigger is wired (`nurRepo: theluckystrike`).
