### PR TITLE
add NicoWeio repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -122,6 +122,10 @@
             "github-contact": "Nick1296",
             "url": "https://github.com/Nick1296/nur-packages"
         },
+        "NicoWeio": {
+            "github-contact": "NicoWeio",
+            "url": "https://github.com/NicoWeio/nur-packages"
+        },
         "NotBalds": {
             "github-contact": "NotBalds",
             "url": "https://github.com/NotBalds/nurpkgs"


### PR DESCRIPTION
So far, [my repository](https://github.com/NicoWeio/nur-packages/) only contains _rainlendar_, but I aim to include a variety of software related to astroparticle physics in the future.

---

The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [x] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

Additionally, the following points are recommended:

- [x] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [x] `meta.description`, so consumers can confirm that that your package is what they're looking for
  - [x] `meta.license`, even for free packages
  - [x] `meta.homepage`, for tracking and deduplication
  - [x] `meta.mainProgram`, so that `nix run` works correctly
