### PR TITLE
repos: add tylerstyle (packages dfdisk)

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -2090,6 +2090,10 @@
             "github-contact": "TwIStOy",
             "url": "https://github.com/TwIStOy/nur-packages"
         },
+        "tylerstyle": {
+            "github-contact": "tylerstyle",
+            "url": "https://github.com/tylerstyle/nur-packages"
+        },
         "uleenucks": {
             "github-contact": "uleenucks",
             "url": "https://github.com/uleenucks/nurpkgs"


### PR DESCRIPTION
### Summary

This PR registers the NUR repository for @tylerstyle ( https://github.com/tylerstyle/nur-packages ).

### Packaged Software

• **dfdisk** : Modern forensic disk imaging, damaged media rescue, and format conversion CLI/TUI tool (v0.1.4).
  • Source: https://github.com/tylerstyle/dfdisk
  • Release: https://github.com/tylerstyle/dfdisk/releases/tag/v0.1.4
  • License: MIT OR Apache-2.0


Consumers will be able to access the package via:
```nix
nur.repos.tylerstyle.dfdisk
```

---

### NUR Checklist

The following points apply when adding a new repository to repos.json

- [x] I ran `./bin/nur format-manifest` after updating `repos.json`
- [x] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [x] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

Additionally, the following points are recommended:

- [x] All applicable `meta` fields have been filled out:
  - [x] `meta.description`: Modern forensic disk imaging, damaged media rescue and conversion CLI/TUI tool
  - [x] `meta.license`: MIT OR Apache-2.0 (`[ mit asl20 ]`)
  - [x] `meta.homepage`: https://github.com/tylerstyle/dfdisk
  - [x] `meta.mainProgram`: `dfdisk`