### PR TITLE
add hetav21 repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -910,6 +910,10 @@
             "github-contact": "herver",
             "url": "https://github.com/herver/nur"
         },
+        "hetav21": {
+            "github-contact": "Hetav21",
+            "url": "https://github.com/Hetav21/NUR"
+        },
         "hexadecimalDinosaur": {
             "github-contact": "hexadecimalDinosaur",
             "url": "https://github.com/hexadecimalDinosaur/nur"


### PR DESCRIPTION
### Packages Included

| Package | License | Description |
| :--- | :--- | :--- |
| `direnv-nvim` | MPL-2.0 | Direnv integration for Neovim written in Lua |
| `wsl-notify-send` | MIT | Send Windows 10/11 toast notifications from WSL |

---

- [x] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [x] By including this repository in NUR, I confirm that any copyrightable content in the repository (other than built derivations or patches, if applicable) is licensed under the MIT license
- [x] I confirm that `meta.license` and `meta.sourceProvenance` have been set correctly for any derivations for unfree or not built from source packages

- [x] All applicable `meta` fields have been filled out. See https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes for more information. The following fields are particularly helpful and can always be filled out:
  - [x] `meta.description`, so consumers can confirm that your package is what they're looking for
  - [x] `meta.license`, even for free packages
  - [x] `meta.homepage`, for tracking and deduplication
  - [x] `meta.mainProgram`, so that `nix run` works correctly